### PR TITLE
Require mtl>=2.0. Bump maxium version of mtl and transformers.

### DIFF
--- a/plush.cabal
+++ b/plush.cabal
@@ -93,8 +93,8 @@ Executable plush
     hashable >= 1.1.2 && < 1.2,
     haskeline >= 0.6.2 && < 0.7,
     http-types >= 0.6.7 && < 0.7,
-    mtl >= 1.1.0 && < 2.1,
-    transformers >= 0.2.2 && < 0.3,
+    mtl >= 2.0 && < 2.2,
+    transformers >= 0.2.2 && < 0.4,
     pretty >= 1.0.1 && < 1.1,
     parsec >= 3.0.1 && < 3.2,
     process >= 1.0.1 && < 1.1,
@@ -122,10 +122,10 @@ Executable recho
     containers >= 0.3.0 && < 0.5,
     directory >= 1.0.1 && < 1.2,
     filepath >= 1.2.0 && < 1.3,
-    mtl >= 1.1.0 && < 2.1,
+    mtl >= 2.0 && < 2.2,
     process >= 1.0.1 && < 1.1,
     text >= 0.11.1 && < 1.12,
-    transformers >= 0.2.2 && < 0.3,
+    transformers >= 0.2.2 && < 0.4,
     unix >= 2.4.0 && < 2.5,
     unordered-containers >= 0.1.4 && < 0.2
 


### PR DESCRIPTION
ShellExec.hs assumes that mtl and transformers are sharing a common set
of monad transformer types, which isn't true for mtl==1.*.
