### PR TITLE
Pull request: Force files to be read as UTF-8, regardless of locale.

### DIFF
--- a/plush.cabal
+++ b/plush.cabal
@@ -79,6 +79,7 @@ Executable plush
     Plush.Server.Utilities
     Plush.Types
     Plush.Types.CommandSummary
+    Plush.Utilities
 
   Build-depends:
     aeson >= 0.5.0 && < 0.7,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -30,6 +30,7 @@ import Plush.DocTest
 import Plush.Parser
 import Plush.Run
 import Plush.Server
+import Plush.Utilities
 
 
 data Options = Options
@@ -94,7 +95,7 @@ main = do
 
 processFile :: Options -> [String] -> IO ()
 processFile opts [] = processStdin opts []
-processFile opts (fp:args) = readFile fp >>= processArg opts . (:(fp:args))
+processFile opts (fp:args) = readUtf8File fp >>= processArg opts . (:(fp:args))
 
 processArg :: Options -> [String] -> IO ()
 processArg _ [] = return ()

--- a/src/Plush/DocTest.hs
+++ b/src/Plush/DocTest.hs
@@ -26,6 +26,7 @@ import System.Process (readProcess)
 
 import Plush.Parser
 import Plush.Run
+import Plush.Utilities
 
 
 data Location = Location { _locFile :: Maybe FilePath, _locLine :: Int }
@@ -111,7 +112,7 @@ extractTests input = skipping $ zip [1..] $ lines input
 
 docTestFile :: FilePath -> IO [Test]
 docTestFile fp =
-    readFile fp >>= return . map (noteFile fp) . extractTests
+    readUtf8File fp >>= return . map (noteFile fp) . extractTests
 
 
 

--- a/src/Plush/Utilities.hs
+++ b/src/Plush/Utilities.hs
@@ -1,0 +1,30 @@
+{-
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Plush.Utilities (
+    readUtf8File,
+    )
+    where
+
+import System.IO
+
+-- | Lazily get a text file's contents as with 'readFile', but assume its
+-- contents are encoded with UTF-8 regardless of the user's current locale.
+readUtf8File :: FilePath -> IO String
+readUtf8File path = do
+    h <- openFile path ReadMode
+    hSetEncoding h utf8
+    hGetContents h


### PR DESCRIPTION
This allows the tests to pass when run from a terminal without LC_ALL or
similar variables set.

Note: I don't know if this is compliant with the POSIX spec, or even whether the spec specifies any particular behavior w.r.t. text encodings.
