### PR TITLE
Fixed andThenM to stop at first ExitFailure. Added test case to demonstrate it.

### DIFF
--- a/src/Plush/Run/Posix.hs
+++ b/src/Plush/Run/Posix.hs
@@ -392,7 +392,7 @@ andThen exitCode _ = exitCode
 
 -- | Sequence 'ExitCode'-returning operations until failure.
 andThenM :: (Monad m) => m ExitCode -> m ExitCode -> m ExitCode
-andThenM = liftM2 andThen
+andThenM a b = do e <- a; if e == ExitSuccess then b else return e
 
 -- | Sequence a list of 'ExitCode'-returning operations until failure.
 untilFailureM :: (Monad m) => (a -> m ExitCode) -> [a] -> m ExitCode

--- a/tests/vars.doctest
+++ b/tests/vars.doctest
@@ -104,7 +104,7 @@ export readonly unassigned environment var
 can't set readonly shell variable
 Note: skipped on other shells as the error message is inconsistent
     # readonly lll=x
-    # lll=y && echo succeed || echo fail        # SKIP: bash sh dash
+    # lll=y && echo succeed || echo fail        # SKIP sh dash bash
     var is read-only: lll
     fail
 
@@ -121,6 +121,21 @@ Note: actually does the wrong thing here, and restores the binding.
     # nnn=2 set mmm=1
     # set | tr -d \'\" | fgrep nnn
     nnn=2
+
+failing variable commands stop after failure
+Note: Skipped in dash because the error message is inconsistent.
+Note: Skipped in sh and bash because they fail this test.
+    # export nnn=1
+    # export ooo=2
+    # export ppp=3
+    # readonly ooo
+    # unset nnn ooo ppp                         # SKIP sh dash bash
+    var is read-only: ooo
+    # env | fgrep nnn                           # SKIP sh dash bash
+    # env | fgrep ooo                           # SKIP sh dash bash
+    ooo=2
+    # env | fgrep ppp                           # SKIP sh dash bash
+    ppp=3
 
 pipe in last test gives an error
     # dummy=test


### PR DESCRIPTION
Hi Mark,

I think you might have missed the last comment I made to the last pull request. I found a bug in my implementation of andThenM. I had assumed that because andThen stopped at the first failure, that liftM2 andThen would too. Anyway, here's the fix along with a test case. This also reveals an inconsistency (bug?) in bash.

Warren
