### PR TITLE
revamp PosixLike's exception handling

### DIFF
--- a/plush.cabal
+++ b/plush.cabal
@@ -51,6 +51,7 @@ Library
     Plush.Main
 
   Other-modules:
+    Control.Monad.Exception
     Paths_plush
     Plush.DocTest
     Plush.DocTest.Posix
@@ -106,7 +107,6 @@ Library
     hashable >= 1.1.2 && < 1.3,
     haskeline >= 0.6.2 && < 0.8,
     http-types >= 0.6.7 && < 0.8,
-    mtl >= 2.0 && < 2.2,
     old-locale >= 1.0 && < 1.1,
     time >= 1.4 && < 1.5,
     transformers >= 0.2.2 && < 0.4,
@@ -165,7 +165,6 @@ Executable recho
     directory >= 1.0.1 && < 1.3,
     filepath >= 1.2.0 && < 1.4,
     hashable >= 1.1.2 && < 1.3,
-    mtl >= 2.0 && < 2.2,
     process >= 1.0.1 && < 1.1.1,
     text >= 0.11.1 && < 1.12,
     transformers >= 0.2.2 && < 0.4,

--- a/src/Control/Monad/Exception.hs
+++ b/src/Control/Monad/Exception.hs
@@ -1,0 +1,180 @@
+{-
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+{-# Language GeneralizedNewtypeDeriving, RankNTypes #-}
+
+{-| This module supports monads that can throw extensible exceptions. The
+    exceptions are the very same from "Control.Exception", and the operations
+    offered very similar, but here they are not limited to 'IO'.
+
+    This code is in the style of both transformers and mtl, and is compatible
+    with them, though doesn't mimic the module structure or offer the complete
+    range of features in those packages.
+
+    This is very similar to 'ErrorT' and 'MonadError', but based on features of
+    "Control.Exception". In particular, it handles the complex case of
+    asynchronous exceptions by including 'mask' in the typeclass. Note that the
+    extensible extensions feature relies the RankNTypes language extension.
+-}
+
+module Control.Monad.Exception (
+    -- * Typeclass
+    -- $mtl
+    MonadException(..),
+
+    -- * Transformer
+    -- $transformer
+    ExceptionT, runExceptionT,
+
+    -- * Utilities
+    -- $utilities
+    catchAll, catchIOError, catchJust, catchIf,
+    onException,
+    bracket, bracket_,
+    finally,
+  ) where
+
+import Prelude hiding (catch)
+
+import Control.Applicative (Alternative, Applicative)
+import Control.Arrow (left)
+import Control.Exception (Exception(..), SomeException(..))
+import qualified Control.Exception as ControlException
+import Control.Monad (liftM, MonadPlus)
+import Control.Monad.Fix (MonadFix)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans.Class (lift, MonadTrans)
+import qualified Control.Monad.Trans.Error as Error
+import qualified Control.Monad.Trans.State.Lazy as LazyState
+import Data.Foldable (Foldable)
+import Data.Traversable (Traversable)
+
+-- $mtl
+-- The mtl style typeclass
+
+class (Monad m) => MonadException m where
+    -- | Throw an exception. Note that this throws when this action is run in
+    -- the monad /@m@/, not when it is applied. It is a generalization of
+    -- "Control.Exception"'s 'Control.Exception.throwIO'.
+    throwM :: (Exception e) => e -> m a
+
+    -- | Provide a handler for exceptions thrown during execution of the first
+    -- action. Note that type of the type of the argument to the handler will
+    -- constrain which exceptions are caught. See "Control.Exception"'s
+    -- 'Control.Exception.catch'.
+    catch :: (Exception e) => m a -> (e -> m a) -> m a
+
+    -- | Runs an action with asynchronous exceptions diabled. The action is
+    -- provided a method for restoring the async. environment to what it was
+    -- at the 'mask' call. See "Control.Exception"'s 'Control.Exception.mask'.
+    mask :: ((forall a. m a -> m a) -> m b) -> m b
+
+instance MonadException IO where
+    throwM = ControlException.throwIO
+    catch = ControlException.catch
+    mask = ControlException.mask
+
+-- Support for other transformers
+instance (MonadException m) => MonadException (LazyState.StateT s m) where
+    throwM e = lift $ throwM e
+    catch = LazyState.liftCatch catch
+    mask a = LazyState.StateT $ \s ->
+        mask $ \u -> LazyState.runStateT (a $ q u) s
+      where
+        q u b = LazyState.StateT $ \s -> u $ LazyState.runStateT b s
+
+
+-- $transformer
+-- The transformers style monad transfomer
+
+-- | Add exception abilities to a monad.
+newtype ExceptionT m a =
+    ExceptionT { unEx :: Error.ErrorT WrappedException m a }
+  deriving (Functor, Foldable, Traversable, Applicative, Alternative,
+            Monad, MonadPlus, MonadFix, MonadTrans, MonadIO)
+
+runExceptionT :: (Monad m) => ExceptionT m a -> m (Either SomeException a)
+runExceptionT = liftM (left unWrapException) . Error.runErrorT . unEx
+
+instance (Monad m) => MonadException (ExceptionT m) where
+    throwM = ExceptionT . Error.throwError . WrapException . toException
+    catch a c = ExceptionT $ unEx a `Error.catchError`
+        (\e -> maybe (Error.throwError e) (unEx . c)
+                (fromException . unWrapException $ e))
+    mask a = a id
+
+
+newtype WrappedException = WrapException { unWrapException :: SomeException }
+instance Error.Error WrappedException where
+    strMsg = WrapException . toException . userError
+
+
+-- $utilities
+-- These functions follow those from "Control.Exception", except that they are
+-- based on methods from the 'MonadException' typeclass. See
+-- "Control.Exception" for API usage.
+
+-- | Catches all exceptions, and somewhat defeats the purpose of the extensible
+-- exception system. Use sparingly.
+catchAll :: (MonadException m) => m a -> (SomeException -> m a) -> m a
+catchAll = catch
+
+-- | Catch all 'IOError' (eqv. 'IOException') exceptions. Still somewhat too
+-- general, but better than using 'catchAll'. See 'catchIf' for an easy way
+-- of catching specific 'IOError's based on the predicates in "System.IO.Error".
+catchIOError :: (MonadException m) => m a -> (IOError -> m a) -> m a
+catchIOError = catch
+
+-- | Catch exceptions only if they pass some predicate. Often useful with the
+-- predicates for testing 'IOError' values in "System.IO.Error".
+catchIf :: (MonadException m, Exception e) =>
+    (e -> Bool) -> m a -> (e -> m a) -> m a
+catchIf f a b = a `catch` (\e -> if f e then b e else throwM e)
+
+-- | A more generalized way of determining which exceptions to catch at
+-- run time.
+catchJust :: (MonadException m, Exception e) =>
+    (e -> Maybe b) -> m a -> (b -> m a) -> m a
+catchJust f a b = a `catch` (\e -> maybe (throwM e) b $ f e)
+
+-- | Run an action only if an exception is thrown in the main action. The
+-- exception is not caught, simply rethrown.
+onException :: (MonadException m) => m a -> m b -> m a
+onException action handler = action `catchAll` (\e -> handler >> throwM e)
+
+-- | Generalized abstracted pattern of safe resource acquisition and release
+-- in the face of exceptions. The first action \"aquires\" some value, which
+-- is \"released\" by the second action at the end. The third action \"uses\"
+-- the value and its result is the result of the 'bracket'.
+--
+-- If an exception occurs during the use, the release still happens before the
+-- exception is rethrown.
+bracket :: (MonadException m) => m a -> (a -> m b) -> (a -> m c) -> m c
+bracket acquire release use = mask $ \unmasked -> do
+    resource <- acquire
+    result <- unmasked (use resource) `onException` release resource
+    _ <- release resource
+    return result
+
+-- | Version of 'bracket' without any value being passed to the second and
+-- third actions.
+bracket_ :: (MonadException m) => m a -> m b -> m c -> m c
+bracket_ before after action = bracket before (const after) (const action)
+
+-- | Perform an action with a finalizer action that is run, even if an
+-- exception occurs.
+finally :: (MonadException m) => m a -> m b -> m a
+finally action finalizer = bracket_ (return ()) finalizer action

--- a/src/Plush/Job/Output.hs
+++ b/src/Plush/Job/Output.hs
@@ -36,11 +36,11 @@ import Control.Applicative ((<$>))
 import Control.Arrow (second)
 import Control.Concurrent
 import Control.Monad (msum, mzero)
-import Control.Monad.Error (catchError)
 import Data.Aeson (json', Value)
 import qualified Data.Attoparsec as A
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as B (createAndTrim)
+import System.IO.Error (catchIOError)
 import System.Posix
 
 
@@ -133,7 +133,7 @@ readAvailable :: Fd -> IO B.ByteString -- TODO: should merge with parsing logic
 readAvailable fd = go [] >>= return . B.concat . reverse
   where
     go bs = next >>= maybe (return bs) (go . (:bs))
-    next = readBuf `catchError` (\_ -> return Nothing)
+    next = readBuf `catchIOError` (\_ -> return Nothing)
     readBuf = do
       b <- B.createAndTrim bufSize $ (\buf ->
                 fromIntegral `fmap` fdReadBuf fd buf bufSize)

--- a/src/Plush/Main.hs
+++ b/src/Plush/Main.hs
@@ -19,7 +19,7 @@ limitations under the License.
 module Plush.Main (plushMain) where
 
 import Control.Monad (when)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.IO.Class (liftIO)
 import Data.List (foldl')
 import System.Console.GetOpt
 import System.Console.Haskeline

--- a/src/Plush/Run.hs
+++ b/src/Plush/Run.hs
@@ -36,8 +36,9 @@ module Plush.Run (
 where
 
 import Control.Arrow (first)
-import Control.Monad.Error
-import Control.Monad.Trans.State
+import qualified Control.Exception as Ex
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State (runStateT)
 import qualified Data.HashMap.Strict as M
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -98,7 +99,7 @@ run act runner = case runner of
 
     RunInTest s t -> do
         let (r,t') = runTest (runStateT act s) t
-        (a, s') <- either throwError return r
+        (a, s') <- either Ex.throwIO return r
         let (oe, t'') = runTest testOutput t'
         putStr $ either show (uncurry (++)) oe
         return (a, RunInTest s' t'')

--- a/src/Plush/Run/Annotate.hs
+++ b/src/Plush/Run/Annotate.hs
@@ -23,7 +23,7 @@ where
 
 import Control.Applicative ((<$>))
 import Control.Monad (filterM)
-import Control.Monad.Error.Class
+import Control.Monad.Exception (catchIOError)
 import Data.List ((\\), isPrefixOf)
 import qualified Data.Map as M
 import Data.Maybe (catMaybes, maybeToList)
@@ -105,7 +105,7 @@ annotate cl cursor = coallesce <$> annoCommandList cl
           return $ map takeFileName matchingPaths
         execAndPrefix p x =
             if isFilePrefixOf p x
-                then isExecutable x `catchError` (\_ -> return False)
+                then isExecutable x `catchIOError` (\_ -> return False)
                 else return False
         isFilePrefixOf p x = p `isPrefixOf` takeFileName x
         allPathFiles = do
@@ -113,7 +113,7 @@ annotate cl cursor = coallesce <$> annoCommandList cl
             pathFiles <- mapM safeGetDirectoryPaths $ splitSearchPath path
             return $ concat pathFiles
         safeGetDirectoryPaths p = do
-            files <- getDirectoryContents p `catchError` (\_ -> return [])
+            files <- getDirectoryContents p `catchIOError` (\_ -> return [])
             return $ map (p </>) files
 
     coallesce = M.toAscList . M.fromListWith (++)

--- a/src/Plush/Run/BuiltIns/Syntax.hs
+++ b/src/Plush/Run/BuiltIns/Syntax.hs
@@ -37,7 +37,7 @@ module Plush.Run.BuiltIns.Syntax (
 
 import Control.Arrow (first, second)
 import Control.Monad (liftM2)
-import Control.Monad.Error (catchError)
+import Control.Monad.Exception (catchAll)
 import Data.List ((\\))
 import Data.Maybe (listToMaybe)
 import Data.Monoid
@@ -175,7 +175,7 @@ perArg cmd opts args = mapM (reportError . cmd opts) args >>= return . maximum
 
 -- | Catch any errors, report them, and return an error exit code.
 reportError :: (PosixLike m) => m ExitCode -> m ExitCode
-reportError act = act `catchError`  (exitMsg 1 . show)
+reportError act = act `catchAll`  (exitMsg 1 . show)
 
 
 -- | A type that can collect information about arguments. The type takes one

--- a/src/Plush/Run/Command.hs
+++ b/src/Plush/Run/Command.hs
@@ -27,6 +27,7 @@ module Plush.Run.Command (
 
 import Control.Applicative ((<$>))
 import Control.Monad
+import Control.Monad.Exception (finally)
 import System.FilePath
 
 import {-# SOURCE #-} Plush.Run.BuiltIns -- see BuiltIns.hs-boot

--- a/src/Plush/Run/Types.hs
+++ b/src/Plush/Run/Types.hs
@@ -28,7 +28,7 @@ module Plush.Run.Types (
     )
 where
 
-import Control.Monad.Error.Class
+import Control.Monad.Exception (catchIOError)
 import qualified Data.Text as T
 
 import Plush.Run.Posix
@@ -45,7 +45,7 @@ failure = return $ ExitFailure 1
 
 exitMsg :: (PosixLike m) => Int -> String -> m ExitCode
 exitMsg e msg = do
-    errStrLn msg `catchError` (\_ -> return ())
+    errStrLn msg `catchIOError` (\_ -> return ())
     return $ if (e == 0) then ExitSuccess else ExitFailure e
 
 notSupported :: (PosixLike m) => String -> m ExitCode

--- a/src/Plush/Server.hs
+++ b/src/Plush/Server.hs
@@ -24,7 +24,7 @@ module Plush.Server (
 
 import Control.Concurrent (forkIO)
 import Control.Monad (replicateM, void)
-import Control.Monad.Trans (liftIO)
+import Control.Monad.IO.Class (liftIO)
 import Data.ByteString.Lazy (fromChunks)
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T


### PR DESCRIPTION
create new exception transformer/mtl code in Control.Monad.Exception
  based on Control.Exception
  has both MonadException typeclass, and ExceptionT transformer
  added new catchAll and catchIOError convience versions of catch
    may still be to general in some places, but now easier to find
  added catchIf function
    which is more handy in some cases than catchJust
  repalced throwIO with more general throwM

remove package dependency on mtl - it just got in the way
replace MonadError IOError from constraints for PosixLike
  with new MonadException
base TestExec on ExceptionT rather than ErrorT
ShellExec gets it all for free

migrate all code to this new system
used new bracket function in a few places
