### PR TITLE
Sane Builtins

### DIFF
--- a/src/Plush/Run/BuiltIns/Utilities.hs
+++ b/src/Plush/Run/BuiltIns/Utilities.hs
@@ -18,7 +18,7 @@ module Plush.Run.BuiltIns.Utilities (
 
     -- $types
     SpecialUtility(..), DirectUtility(..), BuiltInUtility(..),
-    unSpecial, unDirect, unBuiltIn,
+    unSpecial, unDirect, unBuiltIn, unUtility,
 
     )
     where
@@ -76,11 +76,19 @@ unBuiltIn name (BuiltInUtility csu) = bindSummary name csu'
         (Utility e a) -> Utility (runLifted e) (runLifted a)
     runLifted exec args = lift $ exec args
 
+unUtility :: (PosixLike m) => String -> BuiltInUtility m -> Utility m
+unUtility name (BuiltInUtility csu) = bindName name csu
 
 bindSummary :: (PosixLike m) =>
     String -> (CommandSummary -> ShellUtility m) -> ShellUtility m
 bindSummary name csu = Utility (bind utilExecute) (bind utilAnnotate)
   where
     bind f args = getSummary name >>= ($args) . f . csu . fromMaybe s0
+    s0 = CommandSummary (T.pack name) T.empty []
+
+bindName :: (PosixLike m) =>
+    String -> (CommandSummary -> Utility m) -> Utility m
+bindName name csu = csu s0
+  where
     s0 = CommandSummary (T.pack name) T.empty []
 

--- a/src/Plush/Run/Command.hs
+++ b/src/Plush/Run/Command.hs
@@ -88,12 +88,8 @@ commandSearch cmd
                      -- step 1.d.i.b.: exec from file system
                      external fp
                 else go fps
-        go [] = search builtin withEnvVars (BuiltInCommand "/???") $
-                -- step 1.d.ii.: not found on PATH
+        go [] = -- step 1.d.ii.: not found on PATH
                 unknown
-            -- TODO: technically shouldn't run the builtins if not found in
-            -- during path search. But for now, since the test environemnt
-            -- doesn't have them, this will fail to run anything!
 
     search lkup processBindings fc alt =
         maybe alt (\util ->


### PR DESCRIPTION
make some builtins only available in test mode, and have them act as executables

The effect of this change is that our half-implementations of things like fgrep, touch, etc... will no longer be "builtins" under normal operation.
These utilities are requires so that we can run our doctest suite under test mode. Now they appear as executables in test mode (under /bin).
