### PR TITLE
Bug fixes: ~ completion

### DIFF
--- a/src/Plush/Main.hs
+++ b/src/Plush/Main.hs
@@ -108,13 +108,13 @@ initialRunner opts = fmap snd $ run setup (optRunner opts)
     setup :: (PosixLike m) => Shell.ShellExec m ()
     setup = do
         Shell.setName $ optShellName opts
-        Shell.setFlags flags
+        Shell.setFlags $ optSetFlags opts $ baseFlags
         Shell.setArgs $ optShellArgs opts
 
     iIsSet = F.interactive $ optSetFlags opts $ F.defaultFlags
-    flags = if iIsSet
-                then F.defaultInteractiveFlags
-                else F.defaultFlags
+    baseFlags = if iIsSet
+                    then F.defaultInteractiveFlags
+                    else F.defaultFlags
         -- N.B.: Interactive as determined at the command line chooses a base
         -- set of flags, rather than setting just the interactive flag.
 

--- a/src/Plush/Run/Annotate.hs
+++ b/src/Plush/Run/Annotate.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import Control.Monad (filterM)
 import Control.Monad.Exception (catchIOError)
 import Data.List ((\\), isPrefixOf)
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, maybeToList)
 import System.FilePath
 
 
@@ -88,7 +88,12 @@ annotate cl cursor = coallesce <$> annoCommandList cl
             return $ Just (location w, [Completions comps])
         _ -> return Nothing
       where
-        compFiles (pre, post) = map (++post) <$> (pathnameGlob $ pre ++ "*")
+        compFiles (preCursor, postCursor) = map (++postCursor) <$> do
+            (tildePart, pathPart) <- tildeSplit preCursor
+            paths <- pathnameGlob (fromMaybe "" $ tildeDir tildePart)
+                        $ pathPart ++ "*"
+            return $ (maybe id (map . (</>)) $ tildePrefix tildePart) paths
+
 
     noteCmdCompletion w
         | '/' `elem` wordText w = noteCompletion w


### PR DESCRIPTION
This fixes the ~ completion bug. Now you can tab with paths that start with a ~ and completion does the right thing.

Another small fix was not propagating the set flags from the command line into the shell.
