### PR TITLE
Scripts

### DIFF
--- a/data/env
+++ b/data/env
@@ -1,0 +1,30 @@
+# ~/.plush/env
+#
+# This file is sourced by plush when it interactive.
+# It is an interactive shell if any of these are true:
+#   * stdin and stderr are terminals
+#   * invoked with -i option
+#   * started in web server mode (-w)
+# In addition, real and effictive uids & gids must be the same.
+#
+# If you don't want any of this processing, remove the commands from this file
+# but don't delete the file: It is automatically re-created to the default
+# script if it is found missing.
+
+echo ~/.plush/env ...
+
+#
+# Shell Variables
+#
+PS1='⾙ '    # U+2F99 KANGXI RADICAL SHELL
+
+#
+# Common Aliases
+#
+alias ls='ls -F'
+alias ll='ls -lF'
+alias more=less
+alias mv='mv -i'
+alias rm='rm -i'
+alias du='du -h'
+

--- a/data/profile
+++ b/data/profile
@@ -1,0 +1,28 @@
+# ~/.plush/profile
+#
+# This file is sourced by plush when it is run as a login shell.
+# It is a a login shell if any of these are true:
+#   * argv[0] starts with a '-' (login does this)
+#   * invoked with --login option
+#   * started in web server mode (-w)
+#
+# If you don't want any login processing, remove the commands from this file
+# but don't delete the file: It is automatically re-created to the default
+# script if it is found missing.
+
+echo ~/.plush/profile ...
+
+#
+# Clean up history
+#
+find ~/.plush/history -depth -mtime +45 -delete
+    # removes things older than 45 days
+
+#
+# Set ENV - which is the name of a script to load in interactive shells
+#
+ENV=~/.plush/env
+export ENV
+    # N.B.: This script will automatically be sourced by plush next if
+    # it is an interactive shell.
+

--- a/plush.cabal
+++ b/plush.cabal
@@ -86,6 +86,7 @@ Library
     Plush.Run.Posix
     Plush.Run.Posix.Utilities
     Plush.Run.Redirection
+    Plush.Run.Script
     Plush.Run.ShellExec
     Plush.Run.ShellFlags
     Plush.Run.TestExec

--- a/plush.cabal
+++ b/plush.cabal
@@ -13,6 +13,8 @@ Description:
 
 Data-files:
   data/summaries.txt
+  data/profile
+  data/env
   static/audio/*.ogg
   static/css/*.css
   static/css/*.gif

--- a/src/Plush/DocTest.hs
+++ b/src/Plush/DocTest.hs
@@ -28,6 +28,7 @@ import System.IO (hFlush, hSetBuffering, BufferMode(NoBuffering), stdout)
 
 import Plush.DocTest.Posix
 import Plush.Run
+import Plush.Run.Script
 import Plush.Utilities
 
 

--- a/src/Plush/DocTest.hs
+++ b/src/Plush/DocTest.hs
@@ -22,13 +22,16 @@ module Plush.DocTest (
 
 import Control.Applicative ((<$>))
 import Control.Monad (join, when)
+import Control.Monad.Trans.Class (lift)
 import Data.List (foldl', intercalate, isPrefixOf, partition)
 import System.FilePath (takeFileName)
 import System.IO (hFlush, hSetBuffering, BufferMode(NoBuffering), stdout)
 
 import Plush.DocTest.Posix
 import Plush.Run
+import Plush.Run.Execute
 import Plush.Run.Script
+import Plush.Run.TestExec (testOutput)
 import Plush.Utilities
 
 
@@ -221,7 +224,7 @@ runTest t r0 =
         else (Skipped, r0)
   where
     exec (c,"") r =
-        let (result, r') = testRun (execute c >> outputs) r
+        let (result, r') = testRun (execute c >> lift testOutput) r
             actual = case result of
                 Left e -> e
                 Right (out,err) -> err ++ out

--- a/src/Plush/Job.hs
+++ b/src/Plush/Job.hs
@@ -41,7 +41,7 @@ import Plush.Job.Output
 import Plush.Job.StdIO
 import Plush.Job.Types
 import Plush.Run
-import Plush.Run.Execute (execType, ExecuteType(..))
+import Plush.Run.Execute (execType, ExecuteType(..), execute)
 import Plush.Run.Posix.Utilities (writeStr)
 import Plush.Run.Script (parse)
 import Plush.Run.ShellExec (getFlags, setFlags)

--- a/src/Plush/Job.hs
+++ b/src/Plush/Job.hs
@@ -43,6 +43,7 @@ import Plush.Job.Types
 import Plush.Run
 import Plush.Run.Execute (execType, ExecuteType(..))
 import Plush.Run.Posix.Utilities (writeStr)
+import Plush.Run.Script (parse)
 import Plush.Run.ShellExec (getFlags, setFlags)
 import qualified Plush.Run.ShellFlags as F
 

--- a/src/Plush/Main.hs
+++ b/src/Plush/Main.hs
@@ -127,9 +127,10 @@ setupShell opts = do
         maybeRunFile $ Just "/etc/profile"
         Shell.getVar "HOME" >>= maybeRunFile . fmap (</> ".plush/Profile")
     when iIsSet $ do
-        -- TODO(mzero): check that real and effective ids & gids are same
-        Shell.getVar "ENV" >>= maybeRunFile
-        -- TODO(mzero): env should be subject to parameter expansion
+        match <- realAndEffectiveIDsMatch
+        when match $ do
+            Shell.getVar "ENV" >>= maybeRunFile
+            -- TODO(mzero): env should be subject to parameter expansion
   where
     iIsSet = F.interactive $ optSetFlags opts $ F.defaultFlags
     baseFlags = if iIsSet

--- a/src/Plush/Main.hs
+++ b/src/Plush/Main.hs
@@ -108,13 +108,13 @@ initialRunner opts = fmap snd $ run setup (optRunner opts)
     setup :: (PosixLike m) => Shell.ShellExec m ()
     setup = do
         Shell.setName $ optShellName opts
-        Shell.setFlags flags
+        Shell.setFlags $ optSetFlags opts $ baseFlags
         Shell.setArgs $ optShellArgs opts
 
     iIsSet = F.interactive $ optSetFlags opts $ F.defaultFlags
-    flags = if iIsSet
-                then F.defaultInteractiveFlags
-                else F.defaultFlags
+    baseFlags = if iIsSet
+                    then F.defaultInteractiveFlags
+                    else F.defaultFlags
         -- N.B.: Interactive as determined at the command line chooses a base
         -- set of flags, rather than setting just the interactive flag.
 

--- a/src/Plush/Run.hs
+++ b/src/Plush/Run.hs
@@ -27,27 +27,20 @@ module Plush.Run (
     TestRunner,
     testRunner,
     testRun,
-
-    -- * Utility Actions
-    execute,
-    outputs,
     )
 where
 
 import Control.Arrow (first)
 import qualified Control.Exception as Ex
-import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.State (runStateT)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Encoding.Error as T
 
 import Plush.Resource
-import Plush.Run.Execute
 import Plush.Run.Posix
 import Plush.Run.ShellExec
 import Plush.Run.TestExec
-import Plush.Types
 
 
 -- | Encapsulates the state and 'PosixLike' monad of a running shell.
@@ -124,18 +117,3 @@ testRun act runner = case runner of
         let (r, t') = runTest (runStateT act s) t
             (r', s') = either (\e -> (Left $ show e, s)) (first Right) r
         in  (r', TestRunInTest s' t')
-
-
-
--- * Utility Actions
-
-
--- | Run a parsed command line.
-execute :: (PosixLike m) => CommandList -> ShellExec m ExitCode
-execute = shellExec
-
-
--- | Drain and return the output streams for a TestExec
-outputs :: ShellExec TestExec (String, String)
-outputs = lift testOutput
-

--- a/src/Plush/Run/Annotate.hs
+++ b/src/Plush/Run/Annotate.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import Control.Monad (filterM)
 import Control.Monad.Exception (catchIOError)
 import Data.List ((\\), isPrefixOf)
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe, maybeToList)
 import System.FilePath
 
 
@@ -88,7 +88,12 @@ annotate cl cursor = coallesce <$> annoCommandList cl
             return $ Just (location w, [Completions comps])
         _ -> return Nothing
       where
-        compFiles (pre, post) = map (++post) <$> (pathnameGlob $ pre ++ "*")
+        compFiles (preCursor, postCursor) = map (++postCursor) <$> do
+            (tildePart, pathPart) <- tildeSplit preCursor
+            paths <- pathnameGlob (fromMaybe "" $ tildeDir tildePart)
+                        $ pathPart ++ "*"
+            return $ (maybe id (map . (</>)) $ tildePrefix tildePart) paths
+
 
     noteCmdCompletion w
         | '/' `elem` wordText w = noteCompletion w

--- a/src/Plush/Run/Execute.hs
+++ b/src/Plush/Run/Execute.hs
@@ -17,7 +17,7 @@ limitations under the License.
 {-# Language TupleSections #-}
 
 module Plush.Run.Execute (
-    shellExec,
+    execute,
 
     ExecuteType(..),
     execType,
@@ -41,8 +41,8 @@ import Plush.Run.Types
 import Plush.Types
 
 
-shellExec :: (PosixLike m) => CommandList -> ShellExec m ExitCode
-shellExec cl = do
+execute :: (PosixLike m) => CommandList -> ShellExec m ExitCode
+execute cl = do
     flags <- getFlags
     if F.noexec flags
         then success
@@ -148,7 +148,7 @@ execFor (Name _ name) (Just words_) cmds = do
     forLoop (w:ws) = do
         ok <- setVarEntry name (VarShellOnly, VarReadWrite, Just w)
         case ok of
-            ExitSuccess -> shellExec cmds >> forLoop ws
+            ExitSuccess -> execute cmds >> forLoop ws
             e@(ExitFailure {}) -> return e
 
 execFunctionBody :: (PosixLike m) => FunctionBody -> ShellExec m ExitCode

--- a/src/Plush/Run/Posix/Utilities.hs
+++ b/src/Plush/Run/Posix/Utilities.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ instance PosixInStr T.Text where
 
 -- | Read all of a file.
 readAllFile :: (PosixLike m, PosixInStr s) => FilePath -> m s
-readAllFile fp = bracket open closeFd (fmap fromByteString . readAll)
+readAllFile fp = fmap fromByteString $ bracket open closeFd readAll
   where
     open = openFd fp ReadOnly Nothing defaultFileFlags
 

--- a/src/Plush/Run/Posix/Utilities.hs
+++ b/src/Plush/Run/Posix/Utilities.hs
@@ -29,6 +29,7 @@ module Plush.Run.Posix.Utilities (
     -- * Input convenience functions
     PosixInStr(..),
     readAllFile,
+    writeAllFile,
 
     -- * Output convenience functions
     -- $outstr
@@ -56,6 +57,7 @@ import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LT
 import System.Exit
 import System.FilePath
+import qualified System.Posix.Files as P
 
 import Plush.Run.Posix
 
@@ -63,6 +65,9 @@ import Plush.Run.Posix
 -- Instances for strings use lenient UTF-8 decoding.
 class PosixInStr s where
     fromByteString :: L.ByteString -> s
+
+instance PosixInStr B.ByteString where
+    fromByteString = B.concat . L.toChunks
 
 instance PosixInStr L.ByteString where
     fromByteString = id
@@ -83,6 +88,13 @@ readAllFile fp = fmap fromByteString $ bracket open closeFd readAll
   where
     open = openFd fp ReadOnly Nothing defaultFileFlags
 
+-- | Write all of a file.
+writeAllFile :: (PosixLike m, PosixOutStr s) => FilePath -> s -> m ()
+writeAllFile fp s = bracket open closeFd (flip write $ toByteString s)
+  where
+    open = openFd fp WriteOnly (Just ownerRWMode) fileFlags
+    ownerRWMode = P.ownerReadMode `P.unionFileModes` P.ownerWriteMode
+    fileFlags = defaultFileFlags { trunc = True }
 
 -- $outstr
 -- Use these in place of 'putStr' and 'putStrLn', (as well as
@@ -95,6 +107,9 @@ class PosixOutStr s where
     toByteStringLn :: s -> L.ByteString
     toByteStringLn = flip L.snoc nl . toByteString
       where nl = toEnum $ fromEnum '\n'
+
+instance PosixOutStr B.ByteString where
+    toByteString = L.fromChunks . (:[])
 
 instance PosixOutStr L.ByteString where
     toByteString = id

--- a/src/Plush/Run/Script.hs
+++ b/src/Plush/Run/Script.hs
@@ -1,0 +1,76 @@
+{-
+Copyright 2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Plush.Run.Script (
+    parse,
+    parseInput,
+
+    runCommand,
+    runScript,
+    runFile,
+)
+where
+
+import Control.Monad (when)
+
+import Plush.Parser
+import Plush.Pretty
+import Plush.Run.Execute
+import Plush.Run.Posix
+import Plush.Run.Posix.Utilities
+import Plush.Run.ShellExec
+import qualified Plush.Run.ShellFlags as F
+
+
+-- | Parse a command, in the state of the shell. Extracts the aliases from
+-- the shell state to give to the parser. This action should have no side
+-- effects, and the transformed shell state from this action can be safely
+-- ignored.
+parse :: (PosixLike m) => String -> ShellExec m ParseCommandResult
+parse s = getAliases >>= return . flip parseCommand s
+
+-- | Like 'parse', but the string is considered "shell input", and so is
+-- subject the @verbose (@-v@) and @parseout@ (@-P@) shell flags. Therefore,
+-- this operation can have output other potential side effects.
+parseInput :: (PosixLike m) => String -> ShellExec m ParseCommandResult
+parseInput s = do
+    flags <- getFlags
+    when (F.verbose flags) $ errStrLn s
+    pcr <- parse s
+    when (F.parseout flags) $ case pcr of
+        Right (cl, _) -> errStrLn $ pp cl
+        _ -> return ()
+    return pcr
+
+-- | Run a single command, parsed out of a string.
+runCommand :: (PosixLike m) => String -> ShellExec m (ExitCode, Maybe String)
+runCommand cmds = do
+    pcr <- parseInput cmds
+    case pcr of
+        Left errs -> errStrLn errs >> return (ExitFailure 125, Nothing)
+        Right (cl, rest) -> shellExec cl >>= return . (\ec -> (ec, Just rest))
+
+-- | Run all the commands, parsed from a string
+runScript :: (PosixLike m) => String -> ShellExec m ExitCode
+runScript cmds0 = rc (ExitSuccess, Just cmds0)
+  where
+    rc (_, Just cmds) | not (null cmds) = runCommand cmds >>= rc
+    rc (ec, _) = setLastExitCode ec >> return ec
+
+-- | Run all commands from a file.
+runFile :: (PosixLike m) => FilePath -> ShellExec m ExitCode
+runFile fp = readAllFile fp >>= runScript
+    -- TODO(mzero): should this handle errors?

--- a/src/Plush/Run/Script.hs
+++ b/src/Plush/Run/Script.hs
@@ -61,7 +61,7 @@ runCommand cmds = do
     pcr <- parseInput cmds
     case pcr of
         Left errs -> errStrLn errs >> return (ExitFailure 125, Nothing)
-        Right (cl, rest) -> shellExec cl >>= return . (\ec -> (ec, Just rest))
+        Right (cl, rest) -> execute cl >>= return . (\ec -> (ec, Just rest))
 
 -- | Run all the commands, parsed from a string
 runScript :: (PosixLike m) => String -> ShellExec m ExitCode

--- a/src/Plush/Run/ShellExec.hs
+++ b/src/Plush/Run/ShellExec.hs
@@ -283,6 +283,7 @@ instance PosixLike m => PosixLike (ShellExec m) where
     setCloseOnExec = liftT1 setCloseOnExec
 
     getUserHomeDirectoryForName = liftT1 getUserHomeDirectoryForName
+    realAndEffectiveIDsMatch = lift realAndEffectiveIDsMatch
 
     execProcess = liftT3 execProcess
     pipeline cs = do

--- a/src/Plush/Run/TestExec.hs
+++ b/src/Plush/Run/TestExec.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -320,6 +320,7 @@ instance PosixLike TestExec where
     getUserHomeDirectoryForName s = return $ lookup s homeDirs
       where
         homeDirs = [("tester","/home"), ("root","/"), ("nobody","/tmp")]
+    realAndEffectiveIDsMatch = return True
 
     execProcess _env fp args = runFilePrim fp $ \_s fs _fpc dpc n -> do
         case fsExecutable fs dpc n of

--- a/tests/specialparameters.doctest
+++ b/tests/specialparameters.doctest
@@ -100,5 +100,9 @@ The - special parameter expands to the state of the flags
     a
 
 The 0 special parameter exapnds to the name of the shell
-    # echo $0               # ONLY plush
-    plush
+    # echo $0 | fgrep -q plush ; echo $?            # ONLY plush
+    0
+
+Can't have pipe in last test (no idea why)
+    # echo bye
+    bye


### PR DESCRIPTION
These series of patches
1) refactors out script processing
2) supports login and interactive scripts (~/.plush/profile and ~/.plush/env)
3) auto creates those scripts if they don't exist
4) implements more of the shell startup sequence (processing login, scripts, etc...)
5) handles PS1 in terminal mode

Warning: After this set of changes, plush will try to read /etc/profile if it is a login shell - your system probably has one, and it probably makes use of features that Plush can handle yet. This is okay, but error messages will display when you launch.
