### PR TITLE
Bug fixes - argv[0] and tabs

### DIFF
--- a/src/Plush/Parser/Aliases.hs
+++ b/src/Plush/Parser/Aliases.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,6 +35,8 @@ import Control.Monad
 import Data.Char (isAlpha, isDigit)
 import qualified Data.HashMap.Strict as M
 import Text.Parsec
+
+import Plush.Utilities
 
 
 type Aliases = M.HashMap String String
@@ -116,17 +118,17 @@ aliasesInProgress (DAS _ _ stk) = map (\(_, an, _) -> an) stk
 
 endsInBlank :: String -> Bool
 endsInBlank [] = False
-endsInBlank [c] = c == ' '
+endsInBlank [c] = isBlank c
 endsInBlank (_:cs) = endsInBlank cs
-
 
 -- | Workhorse of the stream: Return the next character if any.
 dasUncons :: DealiasingStream -> Maybe (Char, DealiasingStream)
 dasUncons d@(DAS aliases _ _) = nextChar d >>= go
   where
     go (False, c, d') = Just (c, d')     -- not doing alias substitution (AS)
-    go (True, ' ', d') = dasUncons d'    -- drop leading blanks, when doing AS
-    go (True, c, d') =                   -- doing AS, so look at next name
+    go (True, c, d')
+        | isBlank c   = dasUncons d'     -- drop leading blanks, when doing AS
+        | otherwise   =                  -- doing AS, so look at next name
         let (w, dw') = nextNameSpan d
             mr = if null w || w `elem` aliasesInProgress d
                 then Nothing             -- already in progress

--- a/src/Plush/Parser/Tokens.hs
+++ b/src/Plush/Parser/Tokens.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import Text.Parsec
 import Plush.Parser.Aliases (originalSourceColumn)
 import Plush.Parser.Base
 import Plush.Types
+import Plush.Utilities
 
 
 -- This is a complete refactoring of §2.3 & §2.10.1. Those sections are written
@@ -55,7 +56,7 @@ import Plush.Types
 
 whitespace :: ShellParser ()
 whitespace = do
-    skipMany (char ' ')
+    skipMany (satisfy isBlank)
     optional $ char '#' >> skipMany (satisfy (/= '\n'))
 
 tokenize :: ShellParser a -> ShellParser a
@@ -142,7 +143,7 @@ wordContent endP = bits
 bare :: ShellParser WordPart
 bare = Bare <$> many1 (noneOf nonWordChars)
   where
-    nonWordChars = " \n\\\'\"$" ++ operatorStarts
+    nonWordChars = " \t\n\\\'\"$" ++ operatorStarts
     operatorStarts = concatMap (take 1) operators
 
 

--- a/src/Plush/Run/BuiltIns/Evaluation.hs
+++ b/src/Plush/Run/BuiltIns/Evaluation.hs
@@ -32,12 +32,13 @@ import Plush.Run.Posix.Utilities
 import Plush.Run.Script
 import Plush.Run.ShellExec
 import Plush.Run.Types
+import Plush.Utilities
 
 
 eval :: (PosixLike m) => SpecialUtility m
 eval = SpecialUtility . const $ Utility evalExec emptyAnnotate
   where
-    evalExec args = let cmdline = dropWhile (== ' ') $ intercalate " " args in
+    evalExec args = let cmdline = dropWhile isBlank $ intercalate " " args in
         if null cmdline
             then success
             else fst <$> runCommand cmdline

--- a/src/Plush/Run/Command.hs
+++ b/src/Plush/Run/Command.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ commandSearch cmd
                           emptyAnnotate)
     externalExec fp = withEnvVars $ \args -> do
         env <- getEnv
-        execProcess env fp args
+        execProcess fp env cmd args
 
     functionExec fb ef = setShellVars (\args -> withFunContext args $ ef fb)
         -- §2.9.5 states that when executed, functions have the assignment

--- a/src/Plush/Run/Posix.hs
+++ b/src/Plush/Run/Posix.hs
@@ -251,9 +251,9 @@ ioWrite fd = mapM_ (flip B.unsafeUseAsCStringLen writeBuf) . L.toChunks
 
 
 -- | 'execProcess' for 'IO'
-ioExecProcess fp env _cmd args = do
+ioExecProcess fp env cmd args = do
         pid <- P.forkProcess $
-            P.executeFile fp False args (Just env) `catchIOError` handler
+            PM.executeFile0 fp cmd args env `catchIOError` handler
         mStat <- P.getProcessStatus True False pid
         case mStat of
             Just (P.Exited ec)  -> return ec

--- a/src/Plush/Run/Posix.hs
+++ b/src/Plush/Run/Posix.hs
@@ -67,7 +67,6 @@ import System.Posix.Types
 import qualified System.IO as IO
 import qualified System.IO.Error as IO
 import qualified System.Posix as P
-import qualified System.Process as IO
 import qualified System.Posix.Missing as PM
 
 
@@ -146,8 +145,9 @@ class (Functor m, Monad m, MonadException m,
 
     -- From System.Process
 
-    execProcess :: Bindings     -- ^ Environment variable bindings
-                -> FilePath     -- ^ Path to exec
+    execProcess :: FilePath     -- ^ Path to exec
+                -> Bindings     -- ^ Environment variable bindings
+                -> String       -- ^ Command name
                 -> [String]     -- ^ Arguments
                 -> m ExitCode
 
@@ -209,10 +209,7 @@ instance PosixLike IO where
         groupsMatch <- (==) <$> P.getRealGroupID <*> P.getEffectiveGroupID
         return $ usersMatch && groupsMatch
 
-    execProcess env cmd args = do
-        (_, _, _, h) <- IO.createProcess $
-                        (IO.proc cmd args) { IO.env = Just env }
-        IO.waitForProcess h
+    execProcess = ioExecProcess
 
     pipeline = ioPipeline
 
@@ -251,6 +248,20 @@ ioWrite fd = mapM_ (flip B.unsafeUseAsCStringLen writeBuf) . L.toChunks
         m <- fromIntegral `fmap` P.fdWriteBuf fd (castPtr p) (fromIntegral n)
         when (0 <= m && m <= n) $ writeBuf (p `plusPtr` m, n - m)
     writeBuf _ = return ()
+
+
+-- | 'execProcess' for 'IO'
+ioExecProcess fp env _cmd args = do
+        pid <- P.forkProcess $
+            P.executeFile fp False args (Just env) `catchIOError` handler
+        mStat <- P.getProcessStatus True False pid
+        case mStat of
+            Just (P.Exited ec)  -> return ec
+            _                   -> return $ ExitFailure 129
+  where
+    handler _ = P.exitImmediately $ ExitFailure 127
+        -- NOTE(mzero): §2.9.1 seems to imply 126 in this case, but all other
+        -- shells return 127
 
 -- | 'pipeline' for 'IO': fork each action, connected by a daisy chained
 -- series of pipes. The first action gets the original stdInput, the last

--- a/src/Plush/Run/ShellExec.hs
+++ b/src/Plush/Run/ShellExec.hs
@@ -285,7 +285,7 @@ instance PosixLike m => PosixLike (ShellExec m) where
     getUserHomeDirectoryForName = liftT1 getUserHomeDirectoryForName
     realAndEffectiveIDsMatch = lift realAndEffectiveIDsMatch
 
-    execProcess = liftT3 execProcess
+    execProcess = liftT4 execProcess
     pipeline cs = do
         s <- get
         lift $ pipeline [ evalStateT c s | c <- cs ]

--- a/src/Plush/Run/TestExec.hs
+++ b/src/Plush/Run/TestExec.hs
@@ -322,7 +322,7 @@ instance PosixLike TestExec where
         homeDirs = [("tester","/home"), ("root","/"), ("nobody","/tmp")]
     realAndEffectiveIDsMatch = return True
 
-    execProcess _env fp args = runFilePrim fp $ \_s fs _fpc dpc n -> do
+    execProcess fp _env _cmd args = runFilePrim fp $ \_s fs _fpc dpc n -> do
         case fsExecutable fs dpc n of
             Just util -> utilExecute util args
                 -- TODO(mzero): doesn't handle environment correctly, but

--- a/src/Plush/Utilities.hs
+++ b/src/Plush/Utilities.hs
@@ -15,6 +15,7 @@ limitations under the License.
 -}
 
 module Plush.Utilities (
+    isBlank,
     readMaybe,
     readUtf8File,
     displayVersion,
@@ -27,6 +28,13 @@ import System.IO
 
 import qualified Paths_plush as CabalPaths
 
+-- | In the spec, <blank> is defined by the class current locale (§3.74).
+-- In plush, which is always UTF-8 based, it is simply <space> or <tab>. On many
+-- UTF-8 locales have <blank> include a few other (but not all) space chars.
+isBlank :: Char -> Bool
+isBlank ' ' = True
+isBlank '\t' = True
+isBlank _ = False
 
 -- | The missing read function. The string must parse entirely for this to
 -- return a value.


### PR DESCRIPTION
Now that we have if statements I discovered that the alternate form of the test command didn't work:

```
if [ -e README ]; then .... ; fi
```

This failed because the code wasn't passing the command name as `argv[0]` on exec. Instead it was passing the full path as found by path search. This was only discovered because the Mac OS X (and OpenBSD) version of [ acts like test unless `argv[0]` is exactly `[` (rather than `/bin/[`).

Turns out, the base libraries for doing exec (both `System.Process` and `System.Posix.Process`) have no way of passing in a separate `argv[0]` from the executable path. So... had to add that in `System.Posix.Missing`.

Also, while I was in there, I fixed the long standing issue with parsing tabs. _(Why?, you ask. Because now that I had profile loading, if statements, and tests working.... `/etc/profile` had lines that started with tabs, and that was failing!)
