### PR TITLE
Parameter expansion & pattern matching

### DIFF
--- a/plush.cabal
+++ b/plush.cabal
@@ -85,6 +85,7 @@ Library
     Plush.Run.Command
     Plush.Run.Execute
     Plush.Run.Expansion
+    Plush.Run.Pattern
     Plush.Run.Posix
     Plush.Run.Posix.Utilities
     Plush.Run.Redirection

--- a/src/Plush/Run/Annotate.hs
+++ b/src/Plush/Run/Annotate.hs
@@ -92,7 +92,7 @@ annotate cl cursor = coallesce <$> annoCommandList cl
         compFiles (preCursor, postCursor) = map (++postCursor) <$> do
             (tildePart, pathPart) <- tildeSplit preCursor
             paths <- pathnameGlob (fromMaybe "" $ tildeDir tildePart)
-                        $ pathPart ++ "*"
+                        $ [Singlequoted pathPart, Bare "*"]
             return $ (maybe id (map . (</>)) $ tildePrefix tildePart) paths
 
 

--- a/src/Plush/Run/Annotate.hs
+++ b/src/Plush/Run/Annotate.hs
@@ -32,6 +32,7 @@ import System.FilePath
 
 import Plush.Run.Command
 import Plush.Run.Expansion
+import Plush.Run.Pattern
 import Plush.Run.Posix
 import Plush.Run.ShellExec
 import Plush.Run.Types

--- a/src/Plush/Run/Expansion.hs
+++ b/src/Plush/Run/Expansion.hs
@@ -21,21 +21,19 @@ module Plush.Run.Expansion (
     wordExpansionActive,
     TildePart, tildeDir, tildePrefix,
     tildeSplit,
-    pathnameGlob,
     quoteRemoval,
     byPathParts,
     )
 where
 
 import Control.Applicative ((<$>))
-import Control.Monad (foldM)
-import Control.Monad.Exception (catchIOError)
 import Data.Char (isSpace)
-import Data.List (foldl', intercalate, partition, sort, tails)
+import Data.List (intercalate, partition)
 import Data.Maybe (fromMaybe)
-import System.FilePath (combine, (</>))
+import System.FilePath ((</>))
 import Text.Parsec
 
+import Plush.Run.Pattern
 import Plush.Run.Posix
 import Plush.Run.Posix.Utilities
 import Plush.Run.ShellExec
@@ -184,7 +182,6 @@ fieldSplitting ifs = expandParts $
 
 
 
-
 pathnameExpansion :: (PosixLike m) => Word -> m [Word]
 pathnameExpansion =  origIfNull $ (expandPartsM $ glob . compress)
     -- TODO: should skip pathnameExpansion of shell flag -f is set
@@ -194,65 +191,6 @@ pathnameExpansion =  origIfNull $ (expandPartsM $ glob . compress)
     glob _ = return []
 
     origIfNull f a = (\bs -> if null bs then [a] else bs) <$> f a
-
-
-data PatternPart = Literal Char | CharTest (Char -> Bool) | Star
-type Pattern = [PatternPart]
-data PatternAction = AddSlash | MatchContents Pattern
-type PathPattern = [PatternAction]
-
-pathnameGlob :: (PosixLike m) => FilePath -> String -> m [String]
-pathnameGlob base = either (\_err -> return []) match . parse patP ""
-  where
-    match :: (PosixLike m) => PathPattern -> m [String]
-    match = foldM steps [""]
-      where
-        steps fs p = concat `fmap` mapM (step p) fs
-
-        step (MatchContents p) dir = do
-            entries <- getDirectoryContents (ifNull "." $ base </> dir)
-                `catchIOError` (\_ -> return [])
-            return $ map (combine dir) $ sort $ filter (patMatch p) entries
-        step (AddSlash) path = do
-            isDir <- doesDirectoryExist (ifNull "/" $ base </> path)
-            return $ if isDir then [path ++ "/"] else []
-
-    ifNull d s = if null s then d else s
-
-    patP =  many1 (slashP <|> matchP)
-    slashP = char '/' >> return AddSlash
-    matchP = many1 partP >>= return . MatchContents
-    partP = (char '*' >> return Star)
-        <|> (char '?' >> return (CharTest (const True)))
-        <|> (char '\\' >> anyChar >>= return . Literal)
-        <|> (try $ do _ <- char '['
-                      c <- noneOf "/"
-                      first <- if c == '!'
-                               then noneOf "/"
-                               else return c
-                      rest <- many $ noneOf "]/"
-                      _ <- char ']'
-                      let f = if c == '!'
-                              then flip notElem
-                              else flip elem
-                      return $ CharTest (f $ makeCharClass (first:rest)))
-        <|> (noneOf "/" >>= return . Literal)
-
-    makeCharClass :: [Char] -> [Char]
-    makeCharClass []                   = []
-    makeCharClass (begin:'-':end:rest) = [begin .. end] ++ makeCharClass rest
-    makeCharClass (c:cs)               = c : makeCharClass cs
-
-    patMatch :: Pattern -> String -> Bool
-    patMatch pattern s = any null $ foldl' (flip concatMap) [s] matchers
-      where
-        matchers = zipWith g (True:repeat False) pattern
-        g _    (Literal l)  (c:cs)  = if l == c then [cs] else []
-        g True _            ('.':_) = []
-        g _    (CharTest p) (c:cs)  = if p c then [cs] else []
-        g _    Star            cs   = tails cs
-        g _    _               []   = []
-
 
 
 quoteRemoval :: Word -> String

--- a/src/Plush/Run/Expansion.hs
+++ b/src/Plush/Run/Expansion.hs
@@ -189,14 +189,11 @@ fieldSplitting ifs = expandParts $
 
 
 pathnameExpansion :: (PosixLike m) => Word -> m [Word]
-pathnameExpansion =  origIfNull $ (expandPartsM $ glob . compress)
+pathnameExpansion w = results <$> pathnameGlob "" (parts w)
     -- TODO: should skip pathnameExpansion of shell flag -f is set
   where
-    glob :: (PosixLike m) => Parts -> m [Parts]
-    glob [(Bare s)] = pathnameGlob "" s >>= return . map ((:[]).Bare)
-    glob _ = return []
-
-    origIfNull f a = (\bs -> if null bs then [a] else bs) <$> f a
+    results [] = [w]
+    results es = expandParts (const [[Bare e] | e <- es]) w
 
 
 quoteRemoval :: Word -> String

--- a/src/Plush/Run/Expansion.hs
+++ b/src/Plush/Run/Expansion.hs
@@ -95,11 +95,11 @@ parameterExpansion live name pmod = getVar name >>= fmap Expanded . pmodf pmod
     pmodf (PModRemoveSuffix False wd) = remove shortestSuffix wd
     pmodf (PModRemoveSuffix True  wd) = remove longestSuffix wd
 
-    getWord wd = wordText <$> wordExpansion live wd
+    getWord wd = wordExpansion live wd
 
     pAct f wd act v = if f v
         then return $ fromMaybe "" v
-        else getWord wd >>= act
+        else getWord wd >>= act . wordText
 
     ptest _     Nothing  = False
     ptest False (Just _) = True         -- plain mods use any assigned value
@@ -221,12 +221,3 @@ byPathParts f w = unparts <$> mapM f (expandParts (byparts []) w)
     byparts acc (x:ws) = byparts (x:acc) ws
 
     unparts = Word (location w) . intercalate [Bare ":"] . map parts
-
-
-compress :: Parts -> Parts
-compress ((Bare s):(Bare t):ps) = compress $ Bare (s ++ t) : ps
-compress ((Expanded s):(Expanded t):ps) = compress $ (Expanded (s ++ t)) : ps
-compress (p:ps) = p : compress ps
-compress [] = []
-
-

--- a/src/Plush/Run/Pattern.hs
+++ b/src/Plush/Run/Pattern.hs
@@ -35,6 +35,7 @@ import Text.Parsec.String
 
 import Plush.Run.Posix
 import Plush.Run.Posix.Utilities
+import Plush.Types
 
 
 data PatternPart = Literal Char | CharTest (Char -> Bool) | Star | NoMatch
@@ -66,8 +67,15 @@ pattern exclude = many1 partP
 
 -- | Compile a string into a 'Pattern'. If the string is an invalid pattern,
 -- then the resutling pattern will match no strings.
-makePattern :: String -> Pattern
-makePattern = either (\_ -> [NoMatch]) id . parse (pattern "") ""
+makePattern :: Word -> Pattern
+makePattern = concatMap asPattern . compress . parts
+  where
+    asPattern (Bare s)      = strPattern s
+    asPattern (Expanded s)  = strPattern s
+    asPattern p             = litPattern $ partText p
+
+    strPattern = either (\_ -> [NoMatch]) id . parse (pattern "") ""
+    litPattern = map Literal
 
 -- | Match a pattern against a string (anchored at the start), and return a
 -- list of all possible remainders (after the matched part). If the @initialDot@

--- a/src/Plush/Run/Pattern.hs
+++ b/src/Plush/Run/Pattern.hs
@@ -1,0 +1,90 @@
+{-
+Copyright 2012-2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Plush.Run.Pattern (
+    pathnameGlob,
+    )
+where
+
+import Control.Monad (foldM)
+import Control.Monad.Exception (catchIOError)
+import Data.List (foldl', sort, tails)
+import System.FilePath (combine, (</>))
+import Text.Parsec
+
+import Plush.Run.Posix
+import Plush.Run.Posix.Utilities
+
+
+data PatternPart = Literal Char | CharTest (Char -> Bool) | Star
+type Pattern = [PatternPart]
+data PatternAction = AddSlash | MatchContents Pattern
+type PathPattern = [PatternAction]
+
+pathnameGlob :: (PosixLike m) => FilePath -> String -> m [String]
+pathnameGlob base = either (\_err -> return []) match . parse patP ""
+  where
+    match :: (PosixLike m) => PathPattern -> m [String]
+    match = foldM steps [""]
+      where
+        steps fs p = concat `fmap` mapM (step p) fs
+
+        step (MatchContents p) dir = do
+            entries <- getDirectoryContents (ifNull "." $ base </> dir)
+                `catchIOError` (\_ -> return [])
+            return $ map (combine dir) $ sort $ filter (patMatch p) entries
+        step (AddSlash) path = do
+            isDir <- doesDirectoryExist (ifNull "/" $ base </> path)
+            return $ if isDir then [path ++ "/"] else []
+
+    ifNull d s = if null s then d else s
+
+    patP =  many1 (slashP <|> matchP)
+    slashP = char '/' >> return AddSlash
+    matchP = many1 partP >>= return . MatchContents
+    partP = (char '*' >> return Star)
+        <|> (char '?' >> return (CharTest (const True)))
+        <|> (char '\\' >> anyChar >>= return . Literal)
+        <|> (try $ do _ <- char '['
+                      c <- noneOf "/"
+                      first <- if c == '!'
+                               then noneOf "/"
+                               else return c
+                      rest <- many $ noneOf "]/"
+                      _ <- char ']'
+                      let f = if c == '!'
+                              then flip notElem
+                              else flip elem
+                      return $ CharTest (f $ makeCharClass (first:rest)))
+        <|> (noneOf "/" >>= return . Literal)
+
+    makeCharClass :: [Char] -> [Char]
+    makeCharClass []                   = []
+    makeCharClass (begin:'-':end:rest) = [begin .. end] ++ makeCharClass rest
+    makeCharClass (c:cs)               = c : makeCharClass cs
+
+    patMatch :: Pattern -> String -> Bool
+    patMatch pattern s = any null $ foldl' (flip concatMap) [s] matchers
+      where
+        matchers = zipWith g (True:repeat False) pattern
+        g _    (Literal l)  (c:cs)  = if l == c then [cs] else []
+        g True _            ('.':_) = []
+        g _    (CharTest p) (c:cs)  = if p c then [cs] else []
+        g _    Star            cs   = tails cs
+        g _    _               []   = []
+
+
+

--- a/src/Plush/Types.hs
+++ b/src/Plush/Types.hs
@@ -153,6 +153,14 @@ partText (Arithmetic wd) = "$((" ++ wordText wd ++ "))"
 
 partText (Expanded s) = s
 
+compress :: Parts -> Parts
+compress ((Bare s):(Bare t):ps) = compress $ Bare (s ++ t) : ps
+compress ((Expanded s):(Expanded t):ps) = compress $ (Expanded (s ++ t)) : ps
+compress (p:ps) = p : compress ps
+compress [] = []
+
+
+
 
 -- | Source location of a parsed construct. References all the way back to the
 -- original source text. Character positions are enumerated characters from 1.

--- a/src/Plush/Types.hs
+++ b/src/Plush/Types.hs
@@ -90,6 +90,17 @@ data RedirectType
     | RedirInputOutput -- <> (def. 0)
     deriving (Eq, Show)
 
+data ParameterModifier
+    = PModNone
+    | PModUseDefault Bool Word      -- - and :-
+    | PModAssignDefault Bool Word   -- = and :=
+    | PModIndicateError Bool Word   -- ? and :?
+    | PModUseAlternate Bool Word    -- + and :+
+    | PModLength                    -- #
+    | PModRemoveSuffix Bool Word    -- % and %%
+    | PModRemovePrefix Bool Word    -- # and ##
+    deriving (Eq, Show)
+
 data Word = Word { location :: Location, parts :: Parts }
     deriving (Eq, Show)
 
@@ -102,9 +113,9 @@ data WordPart = Bare String
               | Backslashed Char
               | Singlequoted String
               | Doublequoted Parts
-              | Parameter String (Maybe (String,Parts)) -- TODO: Modifier type?
+              | Parameter String ParameterModifier
               | Subcommand CommandList
-              | Arithmetic Parts
+              | Arithmetic Word
               | Expanded String
     deriving (Eq, Show)
 
@@ -117,13 +128,28 @@ partText (Backslashed c) | c == '\n' = ""
                          | otherwise = [c]
 partText (Singlequoted s) = s
 partText (Doublequoted ps) = concatMap partText ps
-partText (Parameter n mm) = "${" ++ n ++ modText mm ++ "}"
+partText (Parameter n mm) = "${" ++ modPre mm ++ n ++ modPost mm ++ "}"
   where
-    modText Nothing = ""
-    modText (Just (m,ps)) = m ++ concatMap partText ps
+    modPre PModLength = "#"
+    modPre _ = ""
+
+    modPost PModNone = ""
+    modPost (PModUseDefault    True  wd) = ':' : '-' : wordText wd
+    modPost (PModUseDefault    False wd) =       '-' : wordText wd
+    modPost (PModAssignDefault True  wd) = ':' : '=' : wordText wd
+    modPost (PModAssignDefault False wd) =       '=' : wordText wd
+    modPost (PModIndicateError True  wd) = ':' : '?' : wordText wd
+    modPost (PModIndicateError False wd) =       '?' : wordText wd
+    modPost (PModUseAlternate  True  wd) = ':' : '+' : wordText wd
+    modPost (PModUseAlternate  False wd) =       '+' : wordText wd
+    modPost PModLength = ""
+    modPost (PModRemoveSuffix  True  wd) = '%' : '%' : wordText wd
+    modPost (PModRemoveSuffix  False wd) =       '%' : wordText wd
+    modPost (PModRemovePrefix  True  wd) = '#' : '#' : wordText wd
+    modPost (PModRemovePrefix  False wd) =       '#' : wordText wd
 
 partText (Subcommand _cl) = "$(...command...)" -- TODO
-partText (Arithmetic ps) = "$((" ++ concatMap partText ps ++ "))"
+partText (Arithmetic wd) = "$((" ++ wordText wd ++ "))"
 
 partText (Expanded s) = s
 

--- a/tests/aliases.doctest
+++ b/tests/aliases.doctest
@@ -28,7 +28,7 @@ Simple command usage
     aaa='apple'
     bbb='banana'
     ccc='casava'
-    # alias -p | tr \" \'           # SKIP dash - a bashism plush supports
+    # alias -p | tr \" \'           # SKIP dash - a supported bashism
     alias aaa='apple'
     alias bbb='banana'
     alias ccc='casava'

--- a/tests/filename.doctest
+++ b/tests/filename.doctest
@@ -106,6 +106,9 @@ What is and isn't expanded
     # echo b\*
     b*
 
+    # echo 'b'*
+    bat.hs beetle.hs
+
 Subdirectories can be matched
     # mkdir america
     # mkdir antarctic

--- a/tests/parameter.doctest
+++ b/tests/parameter.doctest
@@ -1,18 +1,18 @@
--- Copyright 2012 Google Inc. All Rights Reserved.
--- 
+-- Copyright 2012-2013 Google Inc. All Rights Reserved.
+--
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
 -- You may obtain a copy of the License at
--- 
+--
 --     http://www.apache.org/licenses/LICENSE-2.0
--- 
+--
 -- Unless required by applicable law or agreed to in writing, software
 -- distributed under the License is distributed on an "AS IS" BASIS,
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-Parameter expansion tests
+Parameter expansion tests - §2.6.2
 
 Simple tests
     # a=aardvark
@@ -23,3 +23,69 @@ Within double quotes - §2.2.3
     # echo "$a" "${a}" "x$a" "x${a}x"
     aardvark aardvark xaardvark xaardvarkx
 
+Unset, set to null, and set to something
+    # nothing=''
+    # something='apple'
+    # recho "$unknown" "$nothing" "$something"
+    argv[1] = <>
+    argv[2] = <>
+    argv[3] = <apple>
+    # recho "${unknown}" "${nothing}" "${something}"
+    argv[1] = <>
+    argv[2] = <>
+    argv[3] = <apple>
+
+Length operator
+    # echo "${#unknown}" "${#nothing}" "${#something}"
+    0 0 5
+
+Use default operator
+    # recho "${unknown-pear}" "${nothing-pear}" "${something-pear}"
+    argv[1] = <pear>
+    argv[2] = <>
+    argv[3] = <apple>
+    # recho "${unknown:-pear}" "${nothing:-pear}" "${something:-pear}"
+    argv[1] = <pear>
+    argv[2] = <pear>
+    argv[3] = <apple>
+
+Use alternate operator
+    # recho "${unknown+pear}" "${nothing+pear}" "${something+pear}"
+    argv[1] = <>
+    argv[2] = <pear>
+    argv[3] = <pear>
+    # recho "${unknown:+pear}" "${nothing:+pear}" "${something:+pear}"
+    argv[1] = <>
+    argv[2] = <>
+    argv[3] = <pear>
+
+Indicate error operator
+    # : "${unknown?}" "${nothing?}" "${something?}"       # ONLY plush
+    unknown is unset
+    # : "${unknown:?}" "${nothing:?}" "${something:?}"    # ONLY plush
+    unknown is unset or null
+    nothing is unset or null
+    # : "${unknown?one}" "${nothing?two}" "${something?three}"      # ONLY plush
+    unknown: one
+    # : "${unknown:?one}" "${nothing:?two}" "${something:?three}"   # ONLY plush
+    unknown: one
+    nothing: two
+
+Assign default operator
+    # recho "${unknown=pear}" "${nothing=pear}" "${something=pear}"
+    argv[1] = <pear>
+    argv[2] = <>
+    argv[3] = <apple>
+    # recho "$unknown" "$nothing" "$something"
+    argv[1] = <pear>
+    argv[2] = <>
+    argv[3] = <apple>
+    # unset unknown
+    # recho "${unknown:=pear}" "${nothing:=pear}" "${something:=pear}"
+    argv[1] = <pear>
+    argv[2] = <pear>
+    argv[3] = <apple>
+    # recho "$unknown" "$nothing" "$something"
+    argv[1] = <pear>
+    argv[2] = <pear>
+    argv[3] = <apple>

--- a/tests/parameter.doctest
+++ b/tests/parameter.doctest
@@ -109,15 +109,30 @@ Pattern matches, pattern features
     =noodle=
     # echo =${str##*}=
     ==
+
     # echo ${str#[a-m]} ${str#[!a-m]} ${str#[n-z]} ${str#[!n-z]}
     noodle oodle oodle noodle
     # echo ${str#*[aeiou]} ${str#*[!aeiou]}
     odle oodle
-    # str='.a*b?c\d'
+    # str='.noodle'
     # echo ${str#?}     # leading dot matched by wildcard (not true for globs!)
-    a*b?c\d
-    # echo ${str#*\*} ${str#*\?} ${str#*\\}     # SKIP plush
+    noodle
+
+Patterns with quoted pattern characters
+    # str='a*b?c\d'
+    # echo ${str#*\*} ${str#*\?} ${str#*\\}
     b?c\d c\d d
+    # echo ${str#*'*'} ${str#*'?'} ${str#*'\'}
+    b?c\d c\d d
+    # echo ${str#*"*"} ${str#*"?"} ${str#*"\\"}
+    b?c\d c\d d
+
+    # star='*' question='?' backslashes='\\'
+    # echo ${str#*$star} ${str#*$question} ${str#*$backslashes}
+    a*b?c\d *b?c\d d
+    # backslash='\'
+    # echo ${str#*$backslash}   # SKIP dash - spec is mute on trailing backslash
+    a*b?c\d
 
 Pattern matches, longest & shortest
     # str='ababxyxy'
@@ -136,3 +151,36 @@ Patterns on unset vars don't expand the pattern
     ==
     no
 
+Pattern matching examples from spec
+    # unset X
+    # echo ${X:=abc}
+    abc
+
+    # unset posix
+    # set a b c
+    # echo ${3:+posix}
+    posix
+
+    # HOME=/usr/posix
+    # echo ${#HOME}
+    10
+
+    # x=file.c
+    # echo ${x%.c}.o
+    file.o
+
+    # x=posix/src/std
+    # echo ${x%%/*}
+    posix
+
+    # x=$HOME/src/cmd
+    # echo ${x#$HOME}
+    /src/cmd
+
+    # x=/one/two/three
+    # echo ${x##*/}
+    three
+
+    # x='*hi'
+    # echo "${x#*}" ${x#"*"}
+    *hi hi

--- a/tests/parameter.doctest
+++ b/tests/parameter.doctest
@@ -89,3 +89,50 @@ Assign default operator
     argv[1] = <pear>
     argv[2] = <pear>
     argv[3] = <apple>
+
+Pattern matches, simple
+    # str='crabapple'
+    # echo ${str#crab} ${str%apple}
+    apple crab
+    # echo ${str#tree} ${str%tree}
+    crabapple crabapple
+
+Pattern matches, pattern features
+    # str='noodle'
+    # echo ${str#?}
+    oodle
+    # echo ${str#*d}
+    le
+    # echo ${str#*q}
+    noodle
+    # echo =${str#*}=
+    =noodle=
+    # echo =${str##*}=
+    ==
+    # echo ${str#[a-m]} ${str#[!a-m]} ${str#[n-z]} ${str#[!n-z]}
+    noodle oodle oodle noodle
+    # echo ${str#*[aeiou]} ${str#*[!aeiou]}
+    odle oodle
+    # str='.a*b?c\d'
+    # echo ${str#?}     # leading dot matched by wildcard (not true for globs!)
+    a*b?c\d
+    # echo ${str#*\*} ${str#*\?} ${str#*\\}     # SKIP plush
+    b?c\d c\d d
+
+Pattern matches, longest & shortest
+    # str='ababxyxy'
+    # echo ${str#a*b} ${str##a*b}
+    abxyxy xyxy
+    # echo ${str%x*y} ${str%%x*y}
+    ababxy abab
+
+Patterns on unset vars don't expand the pattern
+    # something=yesindeedy
+    # unset unknown
+    # unset run; echo =${something#${run=yes}}=; echo ${run-no}
+    =indeedy=
+    yes
+    # unset run; echo =${unknown#${run=yes}}=; echo ${run-no}
+    ==
+    no
+


### PR DESCRIPTION
Support all the parameter expansion modifiers like `${foo:-bar}` and `${file%.hc}`.

This also entailed filling out support for pattern matching, which is used by some of those modifiers, by pathname expansion, and (eventually) case statements. Pattern matching now handles much more of the spec, including the rather subtle quoting rules.
