### PR TITLE
Control flow - at long last

### DIFF
--- a/plush.cabal
+++ b/plush.cabal
@@ -72,6 +72,7 @@ Library
     Plush.Resource
     Plush.Run.Annotate
     Plush.Run.BuiltIns
+    Plush.Run.BuiltIns.Control
     Plush.Run.BuiltIns.Evaluation
     Plush.Run.BuiltIns.FileSystem
     Plush.Run.BuiltIns.Grep

--- a/src/Plush/Job.hs
+++ b/src/Plush/Job.hs
@@ -47,7 +47,7 @@ import Plush.Run.Posix.Utilities (writeStr)
 import Plush.Run.Script (parse)
 import Plush.Run.ShellExec (getFlags, setFlags)
 import qualified Plush.Run.ShellFlags as F
-
+import Plush.Run.Types (statusExitCode)
 
 
 -- | An opaque type, holding information about a running job.
@@ -145,8 +145,8 @@ runJob st foregroundRIO childPrep r0
   where
     foreground cl runner = do
         setUp Nothing foregroundRIO (return ())
-        (exitStatus, runner') <- runCommand cl runner
-        cleanUp (return ()) exitStatus
+        (status, runner') <- runCommand cl runner
+        cleanUp (return ()) $ statusExitCode status
         return runner'
 
     background cl runner = do
@@ -154,8 +154,8 @@ runJob st foregroundRIO childPrep r0
         pid <- forkProcess $ do
                     childPrep
                     stdIOChildPrep sp
-                    (exitStatus, _runner') <- runCommand cl runner
-                    exitWith exitStatus
+                    (status, _runner') <- runCommand cl runner
+                    exitWith $ statusExitCode status
         rio <- stdIOMasterPrep sp
         setUp (Just pid) rio $ checkUp (stdIOCloseMasters sp) pid
         return runner

--- a/src/Plush/Job/Types.hs
+++ b/src/Plush/Job/Types.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ import qualified Data.HashMap.Lazy as HM
 import qualified Data.Text as T
 import System.Exit
 import qualified System.Posix.Signals as S
+
+import Plush.Run.Types (exitCodeToInt, intToExitCode)
 
 
 -- | Requests to the shell thread are given an identifier by the submitter.
@@ -148,21 +150,18 @@ instance FromJSON OutputItem where
 -- @{ running: false, exitcode: /s/ }@
 newtype FinishedItem = FinishedItem ExitCode
 instance ToJSON FinishedItem where
-    toJSON (FinishedItem ExitSuccess) = exitObject 0
-    toJSON (FinishedItem (ExitFailure i)) = exitObject i
+    toJSON (FinishedItem ec) = exitObject $ exitCodeToInt ec
 instance FromJSON FinishedItem where
     parseJSON (Object v) = do
         r <- v .: "running"
         if r
             then mzero
-            else FinishedItem . asExitCode <$> v .: "exitcode"
+            else FinishedItem . intToExitCode <$> v .: "exitcode"
     parseJSON _ = mzero
 
 exitObject :: Int -> Value
 exitObject i = object [ "running" .= False, "exitcode" .= i ]
 
-asExitCode :: Int -> ExitCode
-asExitCode i = if i == 0 then ExitSuccess else ExitFailure i
 
 -- | Elements of a run response.
 -- JSON serialized simply as each variant's JSON serialization

--- a/src/Plush/Main.hs
+++ b/src/Plush/Main.hs
@@ -43,6 +43,7 @@ import Plush.Run.Posix.Utilities
 import Plush.Run.Script
 import qualified Plush.Run.ShellExec as Shell
 import qualified Plush.Run.ShellFlags as F
+import Plush.Run.Types
 import Plush.Server
 import Plush.Utilities
 
@@ -233,8 +234,8 @@ processScriptNameArgs opts script (name:args)   = processScript opts' script
 processScript :: Options -> String -> IO ()
 processScript opts script = do
     r <- initialRunner opts
-    (ec, _) <- run (runScript script) r
-    exitWith ec
+    (st, _) <- run (runScript script) r
+    exitWith $ statusExitCode st
 
 --
 -- Web & Server Modes

--- a/src/Plush/Main.hs
+++ b/src/Plush/Main.hs
@@ -286,6 +286,7 @@ runRepl = runInputT defaultSettings . repl
             Just input -> do
                 (s, runner'') <- liftIO (run (runCommand input) runner')
                 case s of
+                    (StExit ec, _) -> liftIO $ exitWith ec
                     (_, Just leftOver) | not $ null leftOver ->
                         outputStrLn ("Didn't use whole input: " ++ leftOver)
                     _ -> return ()

--- a/src/Plush/Run/BuiltIns.hs
+++ b/src/Plush/Run/BuiltIns.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,8 +34,6 @@ import Plush.Run.BuiltIns.Trivial
 import Plush.Run.BuiltIns.Utilities
 import Plush.Run.BuiltIns.WorkingDirectory
 import Plush.Run.Posix
-import Plush.Run.ShellExec
-import Plush.Run.Types
 
 
 -- | Special Built-In Utilities (§2.14)
@@ -93,7 +91,7 @@ builtin = flip M.lookup $ M.fromList $ map (fixup unBuiltIn)
 -- | Utilities that should act as executables in the TestExec monad.
 -- These will be found by path search, and then "executed". TestExec arranges
 -- that when the corresponding files are exectued, these run.
-pseudoExecs :: (PosixLike m) => M.HashMap String (Utility m)
+pseudoExecs :: (PosixLike m) => M.HashMap String (RegularUtility m)
 pseudoExecs = M.fromList $ map (fixup unUtility) $
     alwaysBuiltin ++ otherBuiltins
 

--- a/src/Plush/Run/BuiltIns.hs
+++ b/src/Plush/Run/BuiltIns.hs
@@ -24,6 +24,7 @@ where
 
 import qualified Data.HashMap.Strict as M
 
+import Plush.Run.BuiltIns.Control
 import Plush.Run.BuiltIns.Evaluation
 import Plush.Run.BuiltIns.FileSystem
 import Plush.Run.BuiltIns.Grep
@@ -42,23 +43,25 @@ import Plush.Run.Posix
 -- shell.
 special :: (PosixLike m) => String -> Maybe (ShellUtility m)
 special = flip M.lookup $ M.fromList $ map (fixup unSpecial)
-    [ ("complete", complete)
-    , ("context", context)
+    [ (".", dot)
     , (":", colon)
-    , ("set", set)
+    , ("break", break_)
+    , ("continue", continue_)
+    , ("eval", eval)
+    , ("exit", exit_)
     , ("export", export)
     , ("readonly", readonly)
-    , ("unset", unset)
+    , ("return", return_)
+    , ("set", set)
     , ("shift", shift)
-    , (".", dot)
-    , ("eval", eval)
+    , ("unset", unset)
+    -- plush extensions
+    , ("complete", complete)
+    , ("context", context)
     , ("plush-version", plushVersion)
     ]
     -- eventually will include:
-    -- break, continue, exec, exit
-    -- return, times, trap
-    -- plush extensions:
-    -- complete, context
+    -- exec, times, trap
 
 -- | Direct Built-In Utilities (§2.9.1)
 -- These are executed without PATH search. These commands may have side-effects

--- a/src/Plush/Run/BuiltIns.hs-boot
+++ b/src/Plush/Run/BuiltIns.hs-boot
@@ -32,8 +32,8 @@ module Plush.Run.BuiltIns (
     )
 where
 
+import Plush.Run.BuiltIns.Utilities
 import Plush.Run.Posix
-import Plush.Run.ShellExec
 
 special :: (PosixLike m) => String -> Maybe (ShellUtility m)
 direct :: (PosixLike m) => String -> Maybe (ShellUtility m)

--- a/src/Plush/Run/BuiltIns/Control.hs
+++ b/src/Plush/Run/BuiltIns/Control.hs
@@ -1,0 +1,74 @@
+{-
+Copyright 2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Plush.Run.BuiltIns.Control (
+    break_,
+    continue_,
+    exit_,
+    return_,
+    )
+where
+
+import Control.Applicative ((<$>))
+
+import Plush.Run.BuiltIns.Utilities
+import Plush.Run.Posix
+import Plush.Run.Posix.Utilities
+import Plush.Run.ShellExec
+import Plush.Run.Types
+import Plush.Utilities
+
+
+break_ :: (PosixLike m) => SpecialUtility m
+break_ = SpecialUtility . const $
+    Utility (loopControl StBreak) emptyAnnotate
+
+continue_ :: (PosixLike m) => SpecialUtility m
+continue_ = SpecialUtility . const $
+    Utility (loopControl StContinue) emptyAnnotate
+
+loopControl :: (PosixLike m) =>
+    (Int -> ShellStatus) -> Args -> ShellExec m ShellStatus
+loopControl st = oneIntArg $ \arg -> case arg of
+    Nothing         -> return $ st 1
+    Just n | n >= 1 -> return $ st n
+    _               -> exitMsg 127 "argument not >= 1"
+
+
+exit_ :: (PosixLike m) => SpecialUtility m
+exit_ = SpecialUtility . const $
+    Utility (unwindControl StExit) emptyAnnotate
+
+return_ :: (PosixLike m) => SpecialUtility m
+return_ = SpecialUtility . const $
+    Utility (unwindControl StReturn) emptyAnnotate
+
+unwindControl :: (PosixLike m) =>
+    (ExitCode -> ShellStatus) -> Args -> ShellExec m ShellStatus
+unwindControl st = oneIntArg $ \arg -> case arg of
+    Nothing                     -> st <$> getLastExitCode
+    Just n | 0 <= n && n <= 255 -> return $ st $ intToExitCode n
+    _   -> exitMsg 127 "argument not between 0 and 255"
+
+
+oneIntArg :: (PosixLike m) =>
+    (Maybe Int -> ShellExec m ShellStatus) -> Args -> ShellExec m ShellStatus
+oneIntArg act args = case args of
+    [] -> act Nothing
+    [nStr] -> case readMaybe nStr of
+        Just n -> act (Just n)
+        Nothing -> exitMsg 127 "argument not an integer"
+    _ -> exitMsg 127 "two many arugments"

--- a/src/Plush/Run/BuiltIns/Evaluation.hs
+++ b/src/Plush/Run/BuiltIns/Evaluation.hs
@@ -63,9 +63,11 @@ dot = SpecialUtility . const $ Utility dotExec emptyAnnotate
                 bracket_
                     (unless (null args) $ setArgs args)
                     (unless (null args) $ setArgs oldArgs)
-                    (runFile fp)
+                    (handleReturn <$> runFile fp)
             else
                 runFirstFound args fps
 
-    runFirstFound _ [] = exitMsg 127 "script file not found"
-        -- TODO: should be a shell error, exiting non-interactive shells
+    runFirstFound _ [] = shellError 127 "script file not found"
+
+    handleReturn (StReturn ec) = StStatus ec
+    handleReturn st = st

--- a/src/Plush/Run/BuiltIns/Evaluation.hs
+++ b/src/Plush/Run/BuiltIns/Evaluation.hs
@@ -41,7 +41,7 @@ eval = SpecialUtility . const $ Utility evalExec emptyAnnotate
     evalExec args = let cmdline = dropWhile isBlank $ intercalate " " args in
         if null cmdline
             then success
-            else statusExitCode . fst <$> runCommand cmdline
+            else fst <$> runCommand cmdline
 
 
 dot :: (PosixLike m) => SpecialUtility m
@@ -63,7 +63,7 @@ dot = SpecialUtility . const $ Utility dotExec emptyAnnotate
                 bracket_
                     (unless (null args) $ setArgs args)
                     (unless (null args) $ setArgs oldArgs)
-                    (statusExitCode <$> runFile fp)
+                    (runFile fp)
             else
                 runFirstFound args fps
 

--- a/src/Plush/Run/BuiltIns/Evaluation.hs
+++ b/src/Plush/Run/BuiltIns/Evaluation.hs
@@ -41,7 +41,7 @@ eval = SpecialUtility . const $ Utility evalExec emptyAnnotate
     evalExec args = let cmdline = dropWhile isBlank $ intercalate " " args in
         if null cmdline
             then success
-            else fst <$> runCommand cmdline
+            else statusExitCode . fst <$> runCommand cmdline
 
 
 dot :: (PosixLike m) => SpecialUtility m
@@ -63,7 +63,7 @@ dot = SpecialUtility . const $ Utility dotExec emptyAnnotate
                 bracket_
                     (unless (null args) $ setArgs args)
                     (unless (null args) $ setArgs oldArgs)
-                    (runFile fp)
+                    (statusExitCode <$> runFile fp)
             else
                 runFirstFound args fps
 

--- a/src/Plush/Run/BuiltIns/FileSystem.hs
+++ b/src/Plush/Run/BuiltIns/FileSystem.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import Plush.Run.BuiltIns.Syntax
 import Plush.Run.BuiltIns.Utilities
 import Plush.Run.Posix
 import Plush.Run.Posix.Utilities
-import Plush.Run.Types
 
 
 mkdir :: (PosixLike m) => BuiltInUtility m

--- a/src/Plush/Run/BuiltIns/ShellState.hs
+++ b/src/Plush/Run/BuiltIns/ShellState.hs
@@ -190,9 +190,9 @@ unset = SpecialUtility $ stdSyntax options "" go
   where
     options = [ flag 'v', flag 'f' ]
 
-    go "v" names = untilFailureM unsetVarEntry names
+    go "v" names = statusExitCode <$> untilFailureM unsetVarEntry names
     go "f" names = mapM_ unsetFun names >> success
-    go _flags names = untilFailureM unsetVarEntry names
+    go _flags names = statusExitCode <$> untilFailureM unsetVarEntry names
                       `andThenM` (mapM_ unsetFun names >> success)
 
 modifyVar cmdName hasModifier mkVarEntry = SpecialUtility $ stdSyntax options "" go
@@ -200,7 +200,7 @@ modifyVar cmdName hasModifier mkVarEntry = SpecialUtility $ stdSyntax options ""
     options = [ flag 'p' ]  -- echo exports
 
     go "p" [] = showVars >> success
-    go _flags nameVals = untilFailureM defVar nameVals
+    go _flags nameVals = statusExitCode <$> untilFailureM defVar nameVals
 
     showVars = getVars >>= mapM_ (outStr . varFmt) . sort . M.toList
     varFmt (n, ve@(_, _, val)) | hasModifier ve =

--- a/src/Plush/Run/BuiltIns/ShellState.hs
+++ b/src/Plush/Run/BuiltIns/ShellState.hs
@@ -190,9 +190,9 @@ unset = SpecialUtility $ stdSyntax options "" go
   where
     options = [ flag 'v', flag 'f' ]
 
-    go "v" names = statusExitCode <$> untilFailureM unsetVarEntry names
+    go "v" names = untilFailureM unsetVarEntry names
     go "f" names = mapM_ unsetFun names >> success
-    go _flags names = statusExitCode <$> untilFailureM unsetVarEntry names
+    go _flags names = untilFailureM unsetVarEntry names
                       `andThenM` (mapM_ unsetFun names >> success)
 
 modifyVar cmdName hasModifier mkVarEntry = SpecialUtility $ stdSyntax options "" go
@@ -200,7 +200,7 @@ modifyVar cmdName hasModifier mkVarEntry = SpecialUtility $ stdSyntax options ""
     options = [ flag 'p' ]  -- echo exports
 
     go "p" [] = showVars >> success
-    go _flags nameVals = statusExitCode <$> untilFailureM defVar nameVals
+    go _flags nameVals = untilFailureM defVar nameVals
 
     showVars = getVars >>= mapM_ (outStr . varFmt) . sort . M.toList
     varFmt (n, ve@(_, _, val)) | hasModifier ve =

--- a/src/Plush/Run/BuiltIns/Syntax.hs
+++ b/src/Plush/Run/BuiltIns/Syntax.hs
@@ -60,12 +60,12 @@ import Plush.Types.CommandSummary
 --       exec flags args = ...
 --       ...
 -- @
-stdSyntax :: (PosixLike m) =>
-    [OptionSpec a]                  -- ^ options
-    -> a                            -- ^ the initial option state
-    -> (a -> Args -> m ExitCode)    -- ^ utility function
-    -> CommandSummary   -- ^ summary information for error help messages
-    -> Utility m
+stdSyntax :: (PosixLike m, Returnable r) =>
+    [OptionSpec a]          -- ^ options
+    -> a                    -- ^ the initial option state
+    -> (a -> Args -> m r)   -- ^ utility function
+    -> CommandSummary       -- ^ summary information for error help messages
+    -> Utility m r
 stdSyntax options opt0 action summary = Utility exec anno
   where
     exec cmdLineArgs = case mconcat $ processArgs options cmdLineArgs of
@@ -88,7 +88,7 @@ perArg :: (PosixLike m) =>
 perArg cmd opts args = mapM (reportError . cmd opts) args >>= return . maximum
 
 -- | Catch any errors, report them, and return an error exit code.
-reportError :: (PosixLike m) => m ExitCode -> m ExitCode
+reportError :: (PosixLike m, Returnable r) => m r -> m r
 reportError act = act `catchAll`  (exitMsg 1 . show)
 
 

--- a/src/Plush/Run/BuiltIns/WorkingDirectory.hs
+++ b/src/Plush/Run/BuiltIns/WorkingDirectory.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import Plush.Run.BuiltIns.Utilities
 import Plush.Run.Posix
 import Plush.Run.Posix.Utilities
 import Plush.Run.ShellExec
-import Plush.Run.Types
 
 cd :: (PosixLike m) => DirectUtility m
 cd = DirectUtility $ stdSyntax options "L" go

--- a/src/Plush/Run/Command.hs
+++ b/src/Plush/Run/Command.hs
@@ -41,12 +41,12 @@ import Plush.Types
 -- | A function to run a utility. The `Bindings` are the variable assignments
 -- from the command line, since how they are interpreted depends on the type
 -- of utility being invoked.
-type UtilityRunner m = Bindings -> Args -> ShellExec m ExitCode
+type UtilityRunner m = Bindings -> Args -> ShellExec m ShellStatus
 
 -- | To run a shell function, a function to execute the body of the function
 -- must be passed in.
 type FunctionRunner m =
-    (FunctionBody -> ShellExec m ExitCode) -> UtilityRunner m
+    (FunctionBody -> ShellExec m ShellStatus) -> UtilityRunner m
 
 -- | The found action for a utility includes the function (`UtilityRunner`) for
 -- how to execute it. When the utility turns out to be a function, this code
@@ -94,7 +94,7 @@ commandSearch cmd
     search lkup processBindings fc alt =
         maybe alt (\util ->
             return (fc,
-                    UtilityAction (processBindings $ utilExecute util),
+                    UtilityAction (processBindings $ (fmap StStatus) . utilExecute util),
                     utilAnnotate util))
             $ lkup cmd
 
@@ -111,7 +111,7 @@ commandSearch cmd
                           emptyAnnotate)
     externalExec fp = withEnvVars $ \args -> do
         env <- getEnv
-        execProcess fp env cmd args
+        StStatus <$> execProcess fp env cmd args
 
     functionExec fb ef = setShellVars (\args -> withFunContext args $ ef fb)
         -- §2.9.5 states that when executed, functions have the assignment
@@ -123,8 +123,8 @@ commandSearch cmd
     -- TODO: unsure if emptyAnnotate is correct here, or perhaps defaultAnnotate
 
 setShellVars :: (PosixLike m) =>
-                (Args -> ShellExec m ExitCode) ->
-                Bindings -> Args -> ShellExec m ExitCode
+                (Args -> ShellExec m ShellStatus) ->
+                Bindings -> Args -> ShellExec m ShellStatus
 setShellVars exec bindings args =
     untilFailureM setShellVar bindings `andThenM` exec args
   where
@@ -132,8 +132,8 @@ setShellVars exec bindings args =
         setVarEntry name (VarShellOnly, VarReadWrite, Just val)
 
 withEnvVars :: (PosixLike m) =>
-               (Args -> ShellExec m ExitCode) ->
-               Bindings -> Args -> ShellExec m ExitCode
+               (Args -> ShellExec m ShellStatus) ->
+               Bindings -> Args -> ShellExec m ShellStatus
 withEnvVars exec bindings args = do
     prev <- currentVarEntries bindings
     finally (setEnvVars bindings `andThenM` exec args)
@@ -143,7 +143,7 @@ currentVarEntries :: (PosixLike m) =>
     Bindings -> ShellExec m [(String, Maybe VarEntry)]
 currentVarEntries as = mapM (\(name, _) -> (name,) <$> getVarEntry name) as
 
-setEnvVars :: (PosixLike m) => Bindings -> ShellExec m ExitCode
+setEnvVars :: (PosixLike m) => Bindings -> ShellExec m ShellStatus
 setEnvVars bindings = untilFailureM setEnvVar bindings
   where
     setEnvVar (name, val) =

--- a/src/Plush/Run/Command.hs
+++ b/src/Plush/Run/Command.hs
@@ -94,7 +94,7 @@ commandSearch cmd
     search lkup processBindings fc alt =
         maybe alt (\util ->
             return (fc,
-                    UtilityAction (processBindings $ (fmap StStatus) . utilExecute util),
+                    UtilityAction (processBindings $ utilExecute util),
                     utilAnnotate util))
             $ lkup cmd
 

--- a/src/Plush/Run/Execute.hs
+++ b/src/Plush/Run/Execute.hs
@@ -192,6 +192,7 @@ runLoop loopWhen = flip go defaultSuccess
 
 execFunctionBody :: (PosixLike m) => FunctionBody -> ShellExec m ShellStatus
 execFunctionBody (FunctionBody body redirects) =
-    execCompoundCommand body redirects
-
-
+    handleReturn <$> execCompoundCommand body redirects
+  where
+    handleReturn (StReturn ec) = StStatus ec
+    handleReturn st = st

--- a/src/Plush/Run/Execute.hs
+++ b/src/Plush/Run/Execute.hs
@@ -180,8 +180,6 @@ execLoop loopWhen test body = go ExitSuccess
         if loopWhen == isSuccess ec
             then execute body >>= go
             else return lastEc
-    isSuccess (ExitFailure n) | n /= 0 = False
-    isSuccess _ = True
 
 execFunctionBody :: (PosixLike m) => FunctionBody -> ShellExec m ExitCode
 execFunctionBody (FunctionBody body redirects) =

--- a/src/Plush/Run/Execute.hs-boot
+++ b/src/Plush/Run/Execute.hs-boot
@@ -30,6 +30,7 @@ where
 
 import Plush.Run.Posix
 import Plush.Run.ShellExec
+import Plush.Run.Types
 import Plush.Types
 
 execute :: (PosixLike m) => CommandList -> ShellExec m ExitCode

--- a/src/Plush/Run/Execute.hs-boot
+++ b/src/Plush/Run/Execute.hs-boot
@@ -33,4 +33,4 @@ import Plush.Run.ShellExec
 import Plush.Run.Types
 import Plush.Types
 
-execute :: (PosixLike m) => CommandList -> ShellExec m ExitCode
+execute :: (PosixLike m) => CommandList -> ShellExec m ShellStatus

--- a/src/Plush/Run/Expansion.hs
+++ b/src/Plush/Run/Expansion.hs
@@ -160,10 +160,10 @@ parameterExpansion live name pmod
 
 
 commandSubstituion :: (PosixLike m) =>
-    ShellExec m ExitCode -> ShellExec m String
-commandSubstituion action = (process . snd) <$> captureStdout action
+    ShellExec m ShellStatus -> ShellExec m String
+commandSubstituion act = process <$> captureStdout (statusExitCode <$> act)
   where
-    process = trim "" . fromByteString
+    process = trim "" . fromByteString . snd
     trim _ "" = ""
     trim nls (c:cs)
         | c == '\n' = trim (c:nls) cs

--- a/src/Plush/Run/Expansion.hs
+++ b/src/Plush/Run/Expansion.hs
@@ -42,6 +42,7 @@ import Plush.Run.Posix.Utilities
 import {-# SOURCE #-} Plush.Run.Execute (execute)   -- see Execute.hs-boot
 import Plush.Run.Script (runScript)
 import Plush.Run.ShellExec
+import Plush.Run.Types
 import Plush.Types
 
 -- | Like 'expandActive', but preforms the final quote removal as well

--- a/src/Plush/Run/Posix.hs
+++ b/src/Plush/Run/Posix.hs
@@ -31,12 +31,10 @@ module Plush.Run.Posix (
     PosixLikeFileStatus(..),
 
     -- * Misc
-    -- ** Environment bindings
-    Bindings,
+    -- ** stdJson
+    stdJsonInput, stdJsonOutput,
 
     -- * Re-exports
-    -- ** from System.Exit
-    ExitCode(..),
     -- ** from System.Posix.Types
     module System.Posix.Types,
     -- ** from System.Posix.Files
@@ -45,8 +43,6 @@ module Plush.Run.Posix (
     stdInput, stdOutput, stdError,
     OpenMode(..), OpenFileFlags(..), defaultFileFlags,
 
-    -- * Misc
-    stdJsonInput, stdJsonOutput,
 ) where
 
 import Control.Monad.Exception (MonadException)
@@ -57,8 +53,8 @@ import System.Posix.IO (stdInput, stdOutput, stdError,
     OpenMode(..), OpenFileFlags(..), defaultFileFlags)
 import System.Posix.Types
 
+import Plush.Run.Types
 
-type Bindings = [(String, String)]
 
 -- | The low-level operations that make up the Posix interface.
 --

--- a/src/Plush/Run/Redirection.hs
+++ b/src/Plush/Run/Redirection.hs
@@ -26,7 +26,7 @@ import Data.Maybe (fromJust, fromMaybe, isJust, listToMaybe)
 
 import Plush.Run.Expansion
 import Plush.Run.Posix
-import Plush.Run.Posix.Utilities (exitMsg, toByteString)
+import Plush.Run.Posix.Utilities (shellError, toByteString)
 import Plush.Run.ShellExec
 import Plush.Run.Types
 import Plush.Types
@@ -91,13 +91,13 @@ mkPrim (RedirectHere maybeFd hereDoc _w) = Right . RedirHere fd <$> content
             HereDocParsed ls -> contentExpansion $ unlines ls
             HereDocMissing -> return []
 
-withRedirection :: (PosixLike m) => [Redirect] -> ShellExec m ExitCode
-    -> ShellExec m ExitCode
+withRedirection :: (PosixLike m) => [Redirect] -> ShellExec m ShellStatus
+    -> ShellExec m ShellStatus
 withRedirection [] act = act
 withRedirection (r:rs) act = do
     errOrPrim <- mkPrim r
     case errOrPrim of
-        Left err -> exitMsg 125 err
+        Left err -> shellError 125 err
 
         Right (RedirFile destFd fp (om, mfm, off)) -> saveAway destFd $ do
             fileFd <- openFd fp om mfm off

--- a/src/Plush/Run/Redirection.hs
+++ b/src/Plush/Run/Redirection.hs
@@ -26,7 +26,7 @@ import Data.Maybe (fromJust, fromMaybe, isJust, listToMaybe)
 
 import Plush.Run.Expansion
 import Plush.Run.Posix
-import Plush.Run.Posix.Utilities (toByteString)
+import Plush.Run.Posix.Utilities (exitMsg, toByteString)
 import Plush.Run.ShellExec
 import Plush.Run.Types
 import Plush.Types

--- a/src/Plush/Run/Script.hs
+++ b/src/Plush/Run/Script.hs
@@ -34,6 +34,7 @@ import {-# SOURCE #-} Plush.Run.Execute         -- see Execute.hs-boot
 import Plush.Run.Posix
 import Plush.Run.Posix.Utilities
 import Plush.Run.ShellExec
+import Plush.Run.Types
 import qualified Plush.Run.ShellFlags as F
 
 

--- a/src/Plush/Run/Script.hs
+++ b/src/Plush/Run/Script.hs
@@ -70,7 +70,7 @@ runCommand cmds = do
 runScript :: (PosixLike m) => String -> ShellExec m ShellStatus
 runScript cmds0 = rc (StStatus ExitSuccess, Just cmds0)
   where
-    rc (_, Just cmds) | not (null cmds) = runCommand cmds >>= rc
+    rc (StStatus _, Just cmds) | not (null cmds) = runCommand cmds >>= rc
     rc (st, _) = return st
 
 -- | Run all commands from a file.

--- a/src/Plush/Run/ShellExec.hs
+++ b/src/Plush/Run/ShellExec.hs
@@ -32,8 +32,6 @@ module Plush.Run.ShellExec (
     getLastExitCode, setLastExitCode,
     getSummary, loadSummaries,
     primeShellState,
-
-    ShellUtility,
     )
     where
 
@@ -312,4 +310,3 @@ instance PosixLike m => PosixLike (ShellExec m) where
         lift $ pipeline [ evalShell c s | c <- cs ]
     contentFd = liftT1 contentFd
 
-type ShellUtility m = Utility (ShellExec m)

--- a/src/Plush/Run/ShellExec.hs
+++ b/src/Plush/Run/ShellExec.hs
@@ -79,10 +79,16 @@ data ShellState = ShellState
 
 initialShellState :: ShellState
 initialShellState = ShellState
-    { ssShellPid = 0, ssName = "plush", ssArgs = [], ssFlags = defaultFlags,
-      ssVars = M.empty, ssFuns = M.empty, ssAliases = M.empty,
-      ssLastExitCode = ExitSuccess, ssSummaries = M.empty }
-
+    { ssShellPid = 0
+    , ssName = "plush"
+    , ssArgs = []
+    , ssFlags = defaultFlags
+    , ssVars = M.empty
+    , ssFuns = M.empty
+    , ssAliases = M.empty
+    , ssLastExitCode = ExitSuccess
+    , ssSummaries = M.empty
+    }
 
 -- Shell Execution Monad
 
@@ -108,27 +114,27 @@ getName :: (Monad m) => ShellExec m String
 getName = gets ssName
 
 setName :: (Monad m) => String -> ShellExec m ()
-setName name = modify $ (\s -> s { ssName = name })
+setName name = modify $ \s -> s { ssName = name }
 
 getArgs :: (Monad m) => ShellExec m [String]
 getArgs = gets ssArgs
 
 setArgs :: (Monad m) => [String] -> ShellExec m ()
-setArgs args = modify $ (\s -> s { ssArgs = args })
+setArgs args = modify $ \s -> s { ssArgs = args }
 
 getFlags :: (Monad m) => ShellExec m Flags
 getFlags = gets ssFlags
 
 setFlags :: (Monad m) => Flags -> ShellExec m ()
-setFlags flags = modify $ (\s -> s { ssFlags = flags })
+setFlags flags = modify $ \s -> s { ssFlags = flags }
 
 getVars :: (Monad m, Functor m) => ShellExec m Vars
 getVars = gets ssVars
 
 getVar :: (Monad m, Functor m) => String -> ShellExec m (Maybe String)
-getVar name = get >>= return . varOptions
+getVar name = gets varOptions
   where
-    varOptions s = join $ msum $ [normalVar s, specialVar s, positionalVar s]
+    varOptions s = join $ msum [normalVar s, specialVar s, positionalVar s]
     normalVar s = (Just . varValue) `fmap` M.lookup name (ssVars s)
     specialVar s = ($s) `fmap` M.lookup name specialVarActions
     positionalVar s = case readMaybe name of
@@ -233,7 +239,7 @@ getLastExitCode :: (Monad m) => ShellExec m ExitCode
 getLastExitCode = gets ssLastExitCode
 
 setLastExitCode :: (Monad m) => ExitCode -> ShellExec m ()
-setLastExitCode ec = modify $ (\s -> s { ssLastExitCode = ec })
+setLastExitCode ec = modify $ \s -> s { ssLastExitCode = ec }
 
 getSummary :: (Monad m, Functor m) =>
     String -> ShellExec m (Maybe CommandSummary)
@@ -247,8 +253,8 @@ primeShellState :: (PosixLike m) => ShellExec m ()
 primeShellState = do
     pid <- getProcessID
     e <- map asVar `fmap` getInitialEnvironment
-    modify $ (\s ->
-        s { ssShellPid = pid, ssVars = M.fromList e `M.union` ssVars s })
+    modify $ \s ->
+        s { ssShellPid = pid, ssVars = M.fromList e `M.union` ssVars s }
   where
     asVar (var, val) = (var,(VarExported, VarReadWrite, Just val))
 

--- a/src/Plush/Run/ShellExec.hs
+++ b/src/Plush/Run/ShellExec.hs
@@ -139,15 +139,12 @@ getVar name = get >>= return . varOptions
 
     specialVarActions = M.fromList
         [ ("#", Just . show . length . ssArgs)
-        , ("?", Just . show . exitStatus . ssLastExitCode)
+        , ("?", Just . show . exitCodeToInt . ssLastExitCode)
         , ("-", Just . flagParameter . ssFlags)
         , ("$", Just . show . ssShellPid)
         , ("!", const Nothing)
         , ("0", Just . ssName)
         ] -- NOTE: "@" and "*" are handled in Expansion.hs
-
-    exitStatus ExitSuccess = 0
-    exitStatus (ExitFailure n) = n
 
 getVarDefault :: (Monad m, Functor m) => String -> String -> ShellExec m String
 getVarDefault name def = fromMaybe def `fmap` getVar name

--- a/src/Plush/Run/TestExec.hs
+++ b/src/Plush/Run/TestExec.hs
@@ -41,6 +41,7 @@ import System.FilePath
 import System.IO.Error
 
 import Plush.Run.BuiltIns
+import Plush.Run.BuiltIns.Utilities
 import Plush.Run.Posix
 import Plush.Run.Posix.Utilities
 import Plush.Run.Types
@@ -73,7 +74,7 @@ fsFileExists fs dp n = maybe False isFile $ fsItemEntry fs dp n
     isFile (FileItem _) = True
     isFile _ = False
 
-fsExecutable :: FileSystem -> DirPath -> Name -> Maybe (Utility TestExec)
+fsExecutable :: FileSystem -> DirPath -> Name -> Maybe (RegularUtility TestExec)
 fsExecutable fs dp n = fsItemEntry fs dp n >>= iNode >>= getExec
   where
     iNode (FileItem i) = I.lookup i (fsStore fs)
@@ -155,7 +156,7 @@ initialFileSystem = foldl' (flip ($)) rootFS $
     addExec n fs = fsAddINode IExec fs "/bin" n
 
 
-testExecs :: M.HashMap String (Utility TestExec)
+testExecs :: M.HashMap String (RegularUtility TestExec)
 testExecs = pseudoExecs
 
 

--- a/src/Plush/Run/Types.hs
+++ b/src/Plush/Run/Types.hs
@@ -124,11 +124,13 @@ data Annotation = ExpandedTo String
     -- TODO: some of these should probably be Text rather than String
 
 
-data Utility m = Utility
-    { utilExecute  :: Args -> m ExitCode
+
+data Utility m e = Utility
+    { utilExecute  :: Args -> m e
     , utilAnnotate :: Args -> m [[Annotation]]
 --  , utilComplete :: Args -> m Completion
     }
+
 
 emptyAnnotate :: (Monad m) => Args -> m [[Annotation]]
 emptyAnnotate _ = return []

--- a/src/Plush/Run/Types.hs
+++ b/src/Plush/Run/Types.hs
@@ -1,5 +1,5 @@
 {-
-Copyright 2012 Google Inc. All Rights Reserved.
+Copyright 2012-2013 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,9 +16,15 @@ limitations under the License.
 
 module Plush.Run.Types (
     Args,
-    success, failure,
-    exitMsg,
-    notSupported,
+    Bindings,
+
+    -- $exit
+    ExitCode(..),
+    intToExitCode, exitCodeToInt,
+    isSuccess, isFailure,
+
+    ShellStatus(..),
+    statusExitCode,
 
     FoundCommand(..),
     Annotation(..),
@@ -28,29 +34,75 @@ module Plush.Run.Types (
     )
 where
 
-import Control.Monad.Exception (catchIOError)
 import qualified Data.Text as T
+import System.Exit
 
-import Plush.Run.Posix
-import Plush.Run.Posix.Utilities
 import Plush.Types.CommandSummary
 
 
 type Args = [String]
+type Bindings = [(String, String)]
 
-success :: (Monad m) => m ExitCode
-success = return ExitSuccess
+{- $exit
+POSIX has a concept of "Exit Status", which is a numeric value that process
+exits with at completion. It is limited to the range 0..255 by the spec.
+The shell and other utilities sometimes treat 0 as "success" and other values
+as "failure".
 
-failure :: (Monad m) => m ExitCode
-failure = return $ ExitFailure 1
+Haskell's "System.Exit" defines the type 'ExitCode', which plush reuses.
+However, this type is slightly more general, in that it esparates the
+notion of success and failure from the numeric code (which is only supplied
+on failure). This leads to the unfortunate possibility of the value
+@(ExitFailure 0)@. Is this success or failure in a POSIX context?
 
-exitMsg :: (PosixLike m) => Int -> String -> m ExitCode
-exitMsg e msg = do
-    errStrLn msg `catchIOError` (\_ -> return ())
-    return $ if (e == 0) then ExitSuccess else ExitFailure e
+In the interest of harmony with Haskell's common usage, plush uses 'ExitCode'
+to reprsent "Exit Status". Further, to make code clear and consistent, it
+only distinguishes success from failure based on the constructor.
+-}
 
-notSupported :: (PosixLike m) => String -> m ExitCode
-notSupported s = exitMsg 121 ("*** Not Supported: " ++ s)
+-- | Convert a numeric exit status to an 'ExitCode'. Handles selection of the
+-- correct constructor. It is acceptable, and preferable, to apply 'ExitFailure'
+-- to non-zero constant. Otherwise, use this function.
+intToExitCode :: Int -> ExitCode
+intToExitCode i = if i == 0 then ExitSuccess else ExitFailure i
+
+-- | Extract the numeric exit status from an 'ExitCode'
+exitCodeToInt :: ExitCode -> Int
+exitCodeToInt ExitSuccess = 0
+exitCodeToInt (ExitFailure n) = n
+
+-- | Convience function. It is acceptable to just case or match on the
+-- constructors of 'ExitCode' alone.
+isSuccess :: ExitCode -> Bool
+isSuccess ExitSuccess = True
+isSuccess (ExitFailure _) = False
+
+-- | Convience function.  It is acceptable to just case or match on the
+-- constructors of 'ExitCode' alone.
+isFailure :: ExitCode -> Bool
+isFailure = not . isSuccess
+
+
+-- | The result of special utilities, and of operations within the shell itself,
+-- can be more complicated than an 'ExitCode'. Importantly, they include the
+-- idea of "shell error" that causes shell termination in non-interactive
+-- shells, and abort to the user intput loop in interactive ones.
+data ShellStatus = StStatus ExitCode    -- ^ a normal "exit status"
+                 | StError ExitCode     -- ^ a "shell error"
+                 | StExit ExitCode      -- ^ exit utility invoked
+                 | StReturn ExitCode    -- ^ return from function or script
+                 | StBreak Int          -- ^ break looping command
+                 | StContinue Int       -- ^ continue looping command
+    deriving (Eq)
+
+-- | The exit status corresponding to a shell status.
+-- Unhandled control status values are mapped to error exit status values.
+statusExitCode :: ShellStatus -> ExitCode
+statusExitCode (StStatus ec) = ec
+statusExitCode (StError ec) = ec
+statusExitCode (StExit ec) = ec
+statusExitCode (StReturn ec) = ec
+statusExitCode _ = ExitFailure 123
 
 
 -- | The result of searching for a command. See "Plush.Run.BuiltIns" for

--- a/tests/flowcontrol.doctest
+++ b/tests/flowcontrol.doctest
@@ -1,0 +1,148 @@
+-- Copyright 2013 Google Inc. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+Break and Continue tests
+
+    for loops
+        # for y in :-a :-b break-c :-d;
+        + do ${y%%-*}; echo ${y##*-}; done
+        a
+        b
+
+        # for y in :-a :-b continue-c :-d;
+        + do ${y%%-*}; echo ${y##*-}; done
+        a
+        b
+        d
+
+
+    while loops (until assumed the same)
+        # set true : one   true break two   true : three   false : four
+        # while $1; do c=$2 m=$3; shift 3; $c; echo $m; done
+        one
+
+        # set true : one   true continue two   true : three   false : four
+        # while $1; do c=$2 m=$3; shift 3; $c; echo $m; done
+        one
+        three
+
+
+    nested
+        # for outer in alpha beta gamma
+        + do
+        +    echo $outer
+        +    for inner in delta epsilon
+        +    do
+        +        echo $inner
+        +        break 2
+        +        echo --inner--
+        +    done
+        +    echo --outer--
+        + done
+        alpha
+        delta
+
+        # for outer in alpha beta gamma
+        + do
+        +    echo $outer
+        +    for inner in delta epsilon
+        +    do
+        +        echo $inner
+        +        continue 2
+        +        echo --inner--
+        +    done
+        +    echo --outer--
+        + done
+        alpha
+        delta
+        beta
+        delta
+        gamma
+        delta
+
+    TODO(mzero): should test that when n is > nest depth, it breaks/continues
+    from the top most loop (rather than fall off the end of the shell)
+
+Return tests
+
+    basic return
+        # f() { echo a; return; echo b; }
+        # f
+        a
+
+    returns exit code
+        # f() { return 42; }
+        # f; echo $?
+        42
+
+    returns even when nested in a loop
+        # f() { for x in a b c; do echo $x; return; done; }
+        # f
+        a
+
+    returns only one level when nested in a function
+        # f() { echo a; return; echo b; }
+        # g() { echo y; f; echo z; }
+        # g
+        y
+        a
+        z
+
+    returns last command if no code given
+        # f() { true; return; }
+        # f; echo $?
+        0
+
+        # f() { false; return; }
+        # f; echo $?
+        1
+
+    return also returns from dot scripts
+        set up
+        # cd /tmp
+        # rm -rf doctest
+        # mkdir doctest
+        # cd doctest
+
+        return from script
+        # echo 'echo pre' > dottest
+        # echo 'return' >> dottest
+        # echo 'echo post' >> dottest
+        # . ./dottest; echo $?
+        pre
+        0
+
+        return from script with exit code
+        # echo 'echo pre' > dottest
+        # echo 'return 36' >> dottest
+        # echo 'echo post' >> dottest
+        # . ./dottest; echo $?
+        pre
+        36
+
+        return from script even when nested in a loop
+        # echo 'echo pre' > dottest
+        # echo 'for x in a b; do echo $x; return; done' >> dottest
+        # echo 'echo post' >> dottest
+        # . ./dottest
+        pre
+        a
+
+        clean up
+        # cd /tmp
+        # rm -rf doctest
+
+
+Exit tests
+...well, if you can thing of a way to test this, I'm all ears!

--- a/tests/loop.doctest
+++ b/tests/loop.doctest
@@ -24,14 +24,16 @@ tests of parsing - none of these produce output!
     + done
 
 test looping behavior
-N.B.: Don't use the [ ] form of test: It is broken on Mac OS X & OpenBSD (!)
-    # set true uno true dos true tres false cuatro true cinco
+    # set true uno   true dos   true tres   false cuatro   true cinco
     # while $1; do echo $2; shift 2; done
     uno
     dos
     tres
-    # set false moja false mbili false tatu true nne false tano
+
+    # set false moja   false mbili   false tatu   true nne   false tano
     # until $1; do echo $2; shift 2; done
     moja
     mbili
     tatu
+
+

--- a/tests/vars.doctest
+++ b/tests/vars.doctest
@@ -103,8 +103,9 @@ export readonly unassigned environment var
 
 can't set readonly shell variable
 Note: skipped on other shells as the error message is inconsistent
+TODO(mzero): can't test this now that plush ALSO exits on shell error!
     # readonly lll=x
-    # lll=y && echo succeed || echo fail        # ONLY plush
+    # lll=y && echo succeed || echo fail        # SKIP
     var is read-only: lll
 
 per-command exported variable bindings are restored after command exits

--- a/tests/vars.doctest
+++ b/tests/vars.doctest
@@ -124,16 +124,17 @@ Note: actually does the wrong thing here, and restores the binding.
 failing variable commands stop after failure
 Note: Skipped in dash because the error message is inconsistent.
 Note: Skipped in sh and bash because they fail this test.
+TODO(mzero): can't test this now that plush ALSO exits on shell error!
     # export nnn=1
     # export ooo=2
     # export ppp=3
     # readonly ooo
-    # unset nnn ooo ppp                         # SKIP sh dash bash
+    # unset nnn ooo ppp                         # SKIP
     var is read-only: ooo
-    # env | fgrep nnn                           # SKIP sh dash bash
-    # env | fgrep ooo                           # SKIP sh dash bash
+    # env | fgrep nnn                           # SKIP
+    # env | fgrep ooo                           # SKIP
     ooo=2
-    # env | fgrep ppp                           # SKIP sh dash bash
+    # env | fgrep ppp                           # SKIP
     ppp=3
 
 pipe in last test gives an error

--- a/tests/vars.doctest
+++ b/tests/vars.doctest
@@ -106,7 +106,6 @@ Note: skipped on other shells as the error message is inconsistent
     # readonly lll=x
     # lll=y && echo succeed || echo fail        # ONLY plush
     var is read-only: lll
-    fail
 
 per-command exported variable bindings are restored after command exits
     # export mmm=1


### PR DESCRIPTION
This is admittedly quite a big hunk for review!

The changes introduce the concept of `ShellStatus` is a sort of "enhanced" version of `ExitCode` used as the return value from internal shell operations, and special built-ins. This supports operations producing shell errors, which specific semantics in the spec.

It is also used to support break, continue, exit, and return. These special built-ins now produce status values that cause the execution machinery to perform these control-flow operations.

Along the way there was considerable clean up of where some types and functions lived.

There are some known infelicities with adherence to corners of the spec:
- break or continue with n greater than nest depth "overshoots"
- expansion errors (parameter expansion and command substitution) aren't propagated
- syntax errors for the special builtins don't `shellError`
- the web ui doesn't exit on exit
