### PR TITLE
strip ANSI color sequences from ls output in the #status-dir-cwd panel

### DIFF
--- a/static/js/ls-status.js
+++ b/static/js/ls-status.js
@@ -145,10 +145,18 @@ define(['jquery', 'api', 'util'], function($, api, util) {
     api.runStatus(lsCmd, function (d) { statusResults(cwd, d); });
   }
 
+  function stripCSI(out) {
+    // If CLICOLOR is set `ls` will output ANSI CSI SGR codes that
+    // should be stripped before display here. See also:
+    // http://en.wikipedia.org/wiki/ANSI_escape_code
+    // http://en.wikipedia.org/wiki/Control_Sequence_Introducer#CSI_codes
+    return out.replace(/\x1b\[[^m]*m/g, '');
+  }
+
   function parseLsOutput(out) {
     var files = [];
 
-    out.split(/\r?\n/).slice(1, -1).forEach(function(line) {
+    stripCSI(out).split(/\r?\n/).slice(1, -1).forEach(function(line) {
       var items = line.split(/ +/);
       var mode = items[0];
       var type = mode.substring(0, 1);


### PR DESCRIPTION
This occurs when the env has `CLICOLOR=1` and `TERM=xterm-256color` (possibly other slightly different configurations as well)

Before
![screenshot 2014-01-08 20 49 22](https://f.cloud.github.com/assets/26596/1875149/77cb3874-78e9-11e3-9414-c956110f8224.png)

After
![screenshot 2014-01-08 20 48 10](https://f.cloud.github.com/assets/26596/1875151/7a0cfaa0-78e9-11e3-93ea-dbd6307ca865.png)
